### PR TITLE
Update driver info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Fauna, Inc.
+Copyright 2017 Fauna, Inc.
 
 Licensed under the Mozilla Public License, Version 2.0 (the "License"); you may
 not use this software except in compliance with the License. You may obtain a 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FaunaDB JVM Drivers
 
-[![Build Status](https://img.shields.io/travis/faunadb/faunadb-jvm/master.svg?maxAge=21600)](https://travis-ci.org/faunadb/faunadb-jvm)
-[![Coverage Status](https://img.shields.io/codecov/c/github/faunadb/faunadb-jvm/master.svg?maxAge=21600)](https://codecov.io/gh/faunadb/faunadb-jvm/branch/master)
+[![Build Status](https://img.shields.io/travis/fauna/faunadb-jvm/master.svg?maxAge=21600)](https://travis-ci.org/fauna/faunadb-jvm)
+[![Coverage Status](https://img.shields.io/codecov/c/github/fauna/faunadb-jvm/master.svg?maxAge=21600)](https://codecov.io/gh/fauna/faunadb-jvm/branch/master)
 [![Maven Central](https://img.shields.io/maven-central/v/com.faunadb/faunadb-common.svg?maxAge=21600)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.faunadb%22)
-[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/faunadb/faunadb-jvm/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/faunadb-jvm/master/LICENSE)
 
 This repository contains the FaunaDB drivers for the JVM languages. Currently, Java, Android and Scala clients are implemented.
 
@@ -58,9 +58,9 @@ libraryDependencies += ("com.faunadb" %% "faunadb-scala" % "0.3.3")
 
 Javadocs and Scaladocs are hosted on GitHub:
 
-* [faunadb-java](http://faunadb.github.io/faunadb-jvm/0.3.3/faunadb-java/api/)
-* [faunadb-android](http://faunadb.github.io/faunadb-jvm/0.3.3/faunadb-android/api/)
-* [faunadb-scala](http://faunadb.github.io/faunadb-jvm/0.3.3/faunadb-scala/api/)
+* [faunadb-java](http://fauna.github.io/faunadb-jvm/0.3.3/faunadb-java/api/)
+* [faunadb-android](http://fauna.github.io/faunadb-jvm/0.3.3/faunadb-android/api/)
+* [faunadb-scala](http://fauna.github.io/faunadb-jvm/0.3.3/faunadb-scala/api/)
 
 ## Dependencies
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,17 +17,17 @@ val metricsDocUrl = s"http://dropwizard.github.io/metrics/$metricsVersion/apidoc
 val jodaDocUrl = "http://www.joda.org/joda-time/apidocs/"
 val okHttpDocUrl = "https://square.github.io/okhttp/3.x/okhttp/"
 
-val commonApiUrl = s"http://faunadb.github.io/faunadb-jvm/$driverVersion/faunadb-common/api/"
-val scalaApiUrl = s"http://faunadb.github.io/faunadb-jvm/$driverVersion/faunadb-scala/api/"
-val javaDslApiUrl = s"http://faunadb.github.io/faunadb-jvm/$driverVersion/faunadb-java-dsl/api/"
-val javaApiUrl = s"http://faunadb.github.io/faunadb-jvm/$driverVersion/faunadb-java/api/"
-val javaAndroidApiUrl = s"http://faunadb.github.io/faunadb-jvm/$driverVersion/faunadb-android/api/"
+val commonApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-common/api/"
+val scalaApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-scala/api/"
+val javaDslApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-java-dsl/api/"
+val javaApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-java/api/"
+val javaAndroidApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-android/api/"
 
 lazy val publishSettings = Seq(
   version := driverVersion,
   organization := "com.faunadb",
   licenses := Seq("Mozilla Public License" -> url("https://www.mozilla.org/en-US/MPL/2.0/")),
-  homepage := Some(url("https://github.com/faunadb/faunadb-jvm")),
+  homepage := Some(url("https://github.com/fauna/faunadb-jvm")),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
@@ -41,8 +41,8 @@ lazy val publishSettings = Seq(
   },
   pomExtra := (
     <scm>
-      <url>git@github.com:faunadb/faunadb-jvm.git</url>
-      <connection>scm:git:git@github.com:faunadb/faunadb-jvm.git</connection>
+      <url>git@github.com:fauna/faunadb-jvm.git</url>
+      <connection>scm:git:git@github.com:fauna/faunadb-jvm.git</connection>
     </scm>
     <developers>
       <developer>


### PR DESCRIPTION
Bumps copyright date and updates github links for the org change.

Part of https://github.com/fauna/sales-engineering/issues/525.