### PR TITLE
Add joda-convert in order to remove warnings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 1.0.1-SNAPSHOT
 * Adds support to @query type
+* Add joda-convert to avoid compile time warnings
 
 1.0.0
 * Official release

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val jacksonVersion = "2.6.4"
 val jacksonDocVersion = "2.6"
 val metricsVersion = "3.1.0"
 val jodaTimeVersion = "2.9.4"
+val jodaConvert = "1.8.1"
 val baseScalaVersion = "2.11.8"
 
 val javaDocUrl = "http://docs.oracle.com/javase/7/docs/api/"
@@ -103,6 +104,7 @@ lazy val scala = project.in(file("faunadb-scala"))
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.joda" % "joda-convert" % jodaConvert,
       "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
       "org.scalatest" %% "scalatest" % "2.2.1" % "test"),
 
@@ -152,6 +154,7 @@ lazy val javaDsl = project.in(file("faunadb-java-dsl"))
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.joda" % "joda-convert" % jodaConvert,
       "com.google.guava" % "guava" % "19.0",
       "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
       "org.yaml" % "snakeyaml" % "1.14" % "test",
@@ -189,6 +192,7 @@ lazy val java = project.in(file("faunadb-java"))
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.joda" % "joda-convert" % jodaConvert,
       "ch.qos.logback" % "logback-classic" % "1.1.3" % "test",
       "org.yaml" % "snakeyaml" % "1.14" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",


### PR DESCRIPTION
```
[warn] Class org.joda.convert.FromString not found - continuing with a stub.
[warn] Class org.joda.convert.ToString not found - continuing with a stub.
```

Those warning were getting out when using the scala driver as a dependency for your project.