### PR TITLE
README.md: examples: explicitly close client

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ public class Main {
       .at("data").collect(Field.as(Codec.REF));
 
     System.out.println(indexes);
+    
+    client.close();
   }
 }
 
@@ -141,6 +143,8 @@ object Main extends App {
   println(
     Await.result(indexes, Duration.Inf)
   )
+  
+  client.close()
 }
 ```
 


### PR DESCRIPTION
While playing around with the [Fauna tutorial](https://fauna.com/tutorials/crud#getting-started) I noticed the tutorial code, which I was basing off of the samples in the JVM client readme file, was hanging both in SBT and running inside IntelliJ.  After a bit of digging I saw it's because we are not explicitly closing the FaunaClient, so we end up with some leftover netty threads sitting in `kevent0()`.  

Just to make the example more explicit and so nobody gets bit by the same thing, this patch simply adds the call to `close()`.  An alternative would be to wrap all the example code in a `sessionWith { ... }` function which is nice as it ties resource freeing with the tutorial logic falling out of scope, but this seemed like a less invasive change.