### PR TITLE
CI-12: Add dockerfile for running tests in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.idea/
+target/
+.git/
+.gitignore

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,29 @@
+# Take in a runtime image to use for the base system
+# Expects a Debian-based image
+ARG RUNTIME_IMAGE
+
+# Use the docker image provided via build arg
+FROM $RUNTIME_IMAGE
+
+# Install the libraries we need for sbt and dockerize
+RUN apt-get update && apt-get install -y curl bc && rm -rf /var/lib/apt/lists/*
+
+# Copy in the dockerize utility
+ARG DOCKERIZE_VERSION=0.6.0
+RUN curl -sL https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION/dockerize-linux-amd64-v$DOCKERIZE_VERSION.tar.gz | tar -xzC /usr/local/bin
+
+# Copy in the sbt utility
+ARG SBT_VERSION=1.0.3
+RUN curl -sL https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz | tar -xzC /usr/local --strip-components=1
+
+# Copy project into the image
+COPY . /fauna/faunadb-jvm
+
+# Shift over to the project
+WORKDIR /fauna/faunadb-jvm
+
+# Define the default variables for the tests
+ENV FAUNA_ROOT_KEY=secret FAUNA_DOMAIN=db.fauna.com FAUNA_SCHEME=https FAUNA_PORT=443
+
+# Run the tests (after target database is up)
+ENTRYPOINT dockerize -wait "$FAUNA_SCHEME://$FAUNA_DOMAIN:$FAUNA_PORT/ping" -timeout 30s sbt test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+RUNTIME_IMAGE ?= openjdk:8-slim
+DOCKER_RUN_FLAGS = -it --rm
+
+ifdef FAUNA_ROOT_KEY
+DOCKER_RUN_FLAGS += -e FAUNA_ROOT_KEY=$(FAUNA_ROOT_KEY)
+endif
+
+ifdef FAUNA_DOMAIN
+DOCKER_RUN_FLAGS += -e FAUNA_DOMAIN=$(FAUNA_DOMAIN)
+endif
+
+ifdef FAUNA_SCHEME
+DOCKER_RUN_FLAGS += -e FAUNA_SCHEME=$(FAUNA_SCHEME)
+endif
+
+ifdef FAUNA_PORT
+DOCKER_RUN_FLAGS += -e FAUNA_PORT=$(FAUNA_PORT)
+endif
+
+docker-test:
+	docker build -f Dockerfile.test -t faunadb-jvm-test:latest --build-arg RUNTIME_IMAGE=$(RUNTIME_IMAGE) .
+	docker run $(DOCKER_RUN_FLAGS) faunadb-jvm-test:latest

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ public class Main {
 
     Person person = client.query(Get(Ref(Class("people"), "123456789"))).get()
       .get(PERSON_FIELD);
-    
+
     System.out.println(person);
 
     client.close();
@@ -174,7 +174,7 @@ object Main extends App {
   println(
     Await.result(person, Duration.Inf)
   )
-  
+
   client.close()
 }
 ```
@@ -188,6 +188,10 @@ The faunadb-jvm project is built using sbt:
 To build and run tests against cloud, set the env variable
 `FAUNA_ROOT_KEY` to your admin key secret and run `sbt test` from the
 project directory.
+
+Alternatively, tests can be run via a Docker container with
+`FAUNA_ROOT_KEY="your-cloud-secret" make docker-test` (an alternate
+Debian-based JDK image can be provided via `RUNTIME_IMAGE`).
 
 To run tests against an enterprise cluster or developer instance, you
 will also need to set `FAUNA_SCHEME` (http or https), `FAUNA_DOMAIN`


### PR DESCRIPTION
Works in Jenkins (when building against a Java 8 image; Java 7 doesn't seem to build atm, but I don't think that's the fault of anything I'm doing here).