### PR TITLE
ENG-804: Small code quality improvements to JVM driver

### DIFF
--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/query/Language.java
@@ -152,7 +152,7 @@ public final class Language {
     private final List<Expr> segments;
 
     private Path() {
-      this(Collections.<Expr>emptyList());
+      this(Collections.emptyList());
     }
 
     private Path(List<Expr> segments) {
@@ -166,7 +166,7 @@ public final class Language {
      * @return a new narrowed path
      */
     public Path at(String... others) {
-      List<Expr> all = new ArrayList<>();
+      List<Expr> all = new ArrayList<>(segments.size() + others.length);
       all.addAll(segments);
 
       for (String segment : others) {
@@ -183,7 +183,7 @@ public final class Language {
      * @return a new narrowed path
      */
     public Path at(int... others) {
-      List<Expr> all = new ArrayList<>();
+      List<Expr> all = new ArrayList<>(segments.size() + others.length);
       all.addAll(segments);
 
       for (int segment : others) {
@@ -2199,7 +2199,6 @@ public final class Language {
    * @param value a strings
    * @param find  a substring to locate
    * @return      the offset of where the substring starts or -1 if not found
-   * @return      the offset of where the substring starts or -1 if not found
    * @see <a href="https://app.fauna.com/documentation/reference/queryapi#string-functions">FaunaDB String Functions</a>
    * @see #Value(String)
    */
@@ -2212,7 +2211,6 @@ public final class Language {
    *
    * @param value a strings
    * @param find  a substring to locate
-   * @return      the offset of where the substring starts or -1 if not found
    * @return      the offset of where the substring starts or -1 if not found
    * @see <a href="https://app.fauna.com/documentation/reference/queryapi#string-functions">FaunaDB String Functions</a>
    * @see #Value(String)
@@ -3770,8 +3768,6 @@ public final class Language {
    * @return      the string with leading and trailing whitespace removed
    * Trim function returns
    *
-   * @param value a strings
-   * @return a new {@link Expr} instance
    * @see <a href="https://app.fauna.com/documentation/reference/queryapi#string-functions">FaunaDB String Functions</a>
    * @see #Value(String)
    */

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/query/Pagination.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/query/Pagination.java
@@ -61,13 +61,17 @@ public final class Pagination extends Expr {
     Map<String, Expr> res = new LinkedHashMap<>();
     res.put("paginate", resource);
 
-    if (cursor.isPresent()) res.put(cursor.get().name, cursor.get().ref);
-    if (events.isPresent()) res.put("events", events.get());
-    if (sources.isPresent()) res.put("sources", sources.get());
-    if (ts.isPresent()) res.put("ts", ts.get());
-    if (size.isPresent()) res.put("size", size.get());
+    cursor.ifPresent(cur -> res.put(cur.name, cur.ref));
+    putIfPresent(events, res, "events");
+    putIfPresent(sources, res, "sources");
+    putIfPresent(ts, res, "ts");
+    putIfPresent(size, res, "size");
 
     return Collections.unmodifiableMap(res);
+  }
+
+  private static void putIfPresent(Optional<Expr> optExpr, Map<String, Expr> res, String name) {
+    optExpr.ifPresent(expr -> res.put(name, expr));
   }
 
   /**
@@ -77,7 +81,7 @@ public final class Pagination extends Expr {
    * @return this {@link Pagination} instance
    */
   public Pagination before(Expr cursor) {
-    this.cursor = Optional.<Cursor>of(new Before(cursor));
+    this.cursor = Optional.of(new Before(cursor));
     return this;
   }
 
@@ -88,7 +92,7 @@ public final class Pagination extends Expr {
    * @return this {@link Pagination} instance
    */
   public Pagination after(Expr cursor) {
-    this.cursor = Optional.<Cursor>of(new After(cursor));
+    this.cursor = Optional.of(new After(cursor));
     return this;
   }
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Codec.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Codec.java
@@ -95,17 +95,17 @@ public interface Codec<T> {
   /**
    * Converts a {@link Value} to a {@link RefV}
    */
-  Codec<RefV> REF = Transformations.mapTo(RefV.class, Function.<RefV>identity(), Transformations.<RefV, Value>upCast());
 
+  Codec<RefV> REF = Transformations.mapTo(RefV.class, Function.identity(), Transformations.upCast());
   /**
    * Converts a {@link Value} to a {@link SetRefV}
    */
-  Codec<SetRefV> SET_REF = Transformations.mapTo(SetRefV.class, Function.<SetRefV>identity(), Transformations.<SetRefV, Value>upCast());
+  Codec<SetRefV> SET_REF = Transformations.mapTo(SetRefV.class, Function.identity(), Transformations.upCast());
 
   /**
    * Converts a {@link Value} to a {@link Long}
    */
-  Codec<Long> LONG = Transformations.mapTo(LongV.class, Transformations.<LongV, Long>scalarValue(), Transformations.LONG_TO_VALUE);
+  Codec<Long> LONG = Transformations.mapTo(LongV.class, Transformations.scalarValue(), Transformations.LONG_TO_VALUE);
 
   /**
    * Converts a {@link Value} to a {@link Integer}
@@ -135,12 +135,12 @@ public interface Codec<T> {
   /**
    * Converts a {@link Value} to a {@link String}
    */
-  Codec<String> STRING = Transformations.mapTo(StringV.class, Transformations.<StringV, String>scalarValue(), Transformations.STRING_TO_VALUE);
+  Codec<String> STRING = Transformations.mapTo(StringV.class, Transformations.scalarValue(), Transformations.STRING_TO_VALUE);
 
   /**
    * Converts a {@link Value} to a {@link Double}
    */
-  Codec<Double> DOUBLE = Transformations.mapTo(DoubleV.class, Transformations.<DoubleV, Double>scalarValue(), Transformations.DOUBLE_TO_VALUE);
+  Codec<Double> DOUBLE = Transformations.mapTo(DoubleV.class, Transformations.scalarValue(), Transformations.DOUBLE_TO_VALUE);
 
   /**
    * Converts a {@link Value} to a {@link Float}
@@ -150,12 +150,12 @@ public interface Codec<T> {
   /**
    * Converts a {@link Value} to a {@link Boolean}
    */
-  Codec<Boolean> BOOLEAN = Transformations.mapTo(BooleanV.class, Transformations.<BooleanV, Boolean>scalarValue(), Transformations.BOOLEAN_TO_VALUE);
+  Codec<Boolean> BOOLEAN = Transformations.mapTo(BooleanV.class, Transformations.scalarValue(), Transformations.BOOLEAN_TO_VALUE);
 
   /**
    * Converts a {@link Value} to a {@link LocalDate}
    */
-  Codec<LocalDate> DATE = Transformations.mapTo(DateV.class, Transformations.<DateV, LocalDate>scalarValue(), Transformations.LOCAL_DATE_TO_VALUE);
+  Codec<LocalDate> DATE = Transformations.mapTo(DateV.class, Transformations.scalarValue(), Transformations.LOCAL_DATE_TO_VALUE);
 
   /**
    * Converts a {@link Value} to an {@link List} of {@link Value}
@@ -170,7 +170,7 @@ public interface Codec<T> {
   /**
    * Converts a {@link Value} to an array of bytes
    */
-  Codec<byte[]> BYTES = Transformations.mapTo(BytesV.class, Transformations.<BytesV, byte[]>scalarValue(), Transformations.BYTES_TO_VALUE);
+  Codec<byte[]> BYTES = Transformations.mapTo(BytesV.class, Transformations.scalarValue(), Transformations.BYTES_TO_VALUE);
 }
 
 final class Transformations {
@@ -228,12 +228,7 @@ final class Transformations {
   }
 
   static <T extends ScalarValue<R>, R> Function<T, R> scalarValue() {
-    return new Function<T, R>() {
-      @Override
-      public R apply(T input) {
-        return input.value;
-      }
-    };
+    return input -> input.value;
   }
 
   @SuppressWarnings("unchecked")
@@ -243,161 +238,51 @@ final class Transformations {
 
   /// Cast functions
 
-  final static Function<Long, Integer> LONG_TO_INTEGER = new Function<Long, Integer>() {
-    @Override
-    public Integer apply(Long input) {
-      return input.intValue();
-    }
-  };
+  final static Function<Long, Integer> LONG_TO_INTEGER = Long::intValue;
 
-  final static Function<Integer, Long> INTEGER_TO_LONG = new Function<Integer, Long>() {
-    @Override
-    public Long apply(Integer input) {
-      return Long.valueOf(input);
-    }
-  };
+  final static Function<Integer, Long> INTEGER_TO_LONG = Integer::longValue;
 
-  final static Function<Long, Short> LONG_TO_SHORT = new Function<Long, Short>() {
-    @Override
-    public Short apply(Long input) {
-      return input.shortValue();
-    }
-  };
+  final static Function<Long, Short> LONG_TO_SHORT = Long::shortValue;
 
-  final static Function<Short, Long> SHORT_TO_LONG = new Function<Short, Long>() {
-    @Override
-    public Long apply(Short input) {
-      return Long.valueOf(input);
-    }
-  };
+  final static Function<Short, Long> SHORT_TO_LONG = Short::longValue;
 
-  final static Function<Long, Byte> LONG_TO_BYTE = new Function<Long, Byte>() {
-    @Override
-    public Byte apply(Long input) {
-      return input.byteValue();
-    }
-  };
+  final static Function<Long, Byte> LONG_TO_BYTE = Long::byteValue;
 
-  final static Function<Byte, Long> BYTE_TO_LONG = new Function<Byte, Long>() {
-    @Override
-    public Long apply(Byte input) {
-      return Long.valueOf(input);
-    }
-  };
+  final static Function<Byte, Long> BYTE_TO_LONG = Byte::longValue;
 
-  final static Function<Long, Character> LONG_TO_CHAR = new Function<Long, Character>() {
-    @Override
-    public Character apply(Long input) {
-      return (char) input.longValue();
-    }
-  };
+  final static Function<Long, Character> LONG_TO_CHAR = input -> (char) input.longValue();
 
-  final static Function<Character, Long> CHAR_TO_LONG = new Function<Character, Long>() {
-    @Override
-    public Long apply(Character input) {
-      return Long.valueOf(input);
-    }
-  };
+  final static Function<Character, Long> CHAR_TO_LONG = Long::valueOf;
 
-  final static Function<Double, Float> DOUBLE_TO_FLOAT = new Function<Double, Float>() {
-    @Override
-    public Float apply(Double input) {
-      return input.floatValue();
-    }
-  };
+  final static Function<Double, Float> DOUBLE_TO_FLOAT = Double::floatValue;
 
-  final static Function<Float, Double> FLOAT_TO_DOUBLE = new Function<Float, Double>() {
-    @Override
-    public Double apply(Float input) {
-      return Double.valueOf(input);
-    }
-  };
+  final static Function<Float, Double> FLOAT_TO_DOUBLE = Float::doubleValue;
 
   /// Wrap functions
 
-  final static Function<Long, Value> LONG_TO_VALUE = new Function<Long, Value>() {
-    @Override
-    public Value apply(Long input) {
-      return new LongV(input);
-    }
-  };
+  final static Function<Long, Value> LONG_TO_VALUE = LongV::new;
 
-  final static Function<Double, Value> DOUBLE_TO_VALUE = new Function<Double, Value>() {
-    @Override
-    public Value apply(Double input) {
-      return new DoubleV(input);
-    }
-  };
+  final static Function<Double, Value> DOUBLE_TO_VALUE = DoubleV::new;
 
-  final static Function<String, Value> STRING_TO_VALUE = new Function<String, Value>() {
-    @Override
-    public Value apply(String input) {
-      return new StringV(input);
-    }
-  };
+  final static Function<String, Value> STRING_TO_VALUE = StringV::new;
 
-  final static Function<Boolean, Value> BOOLEAN_TO_VALUE = new Function<Boolean, Value>() {
-    @Override
-    public Value apply(Boolean input) {
-      return BooleanV.valueOf(input);
-    }
-  };
+  final static Function<Boolean, Value> BOOLEAN_TO_VALUE = BooleanV::valueOf;
 
-  final static Function<Instant, Value> INSTANT_TO_VALUE = new Function<Instant, Value>() {
-    @Override
-    public Value apply(Instant input) {
-      return new TimeV(input);
-    }
-  };
+  final static Function<Instant, Value> INSTANT_TO_VALUE = TimeV::new;
 
-  final static Function<LocalDate, Value> LOCAL_DATE_TO_VALUE = new Function<LocalDate, Value>() {
-    @Override
-    public Value apply(LocalDate input) {
-      return new DateV(input);
-    }
-  };
+  final static Function<LocalDate, Value> LOCAL_DATE_TO_VALUE = DateV::new;
 
-  final static Function<Map<String, Value>, Value> MAP_TO_VALUE = new Function<Map<String, Value>, Value>() {
-    @Override
-    public Value apply(Map<String, Value> input) {
-      return new ObjectV(input);
-    }
-  };
+  final static Function<Map<String, Value>, Value> MAP_TO_VALUE = ObjectV::new;
 
-  final static Function<List<Value>, Value> LIST_TO_VALUE = new Function<List<Value>, Value>() {
-    @Override
-    public Value apply(List<Value> input) {
-        return new ArrayV(Collections.unmodifiableList(input));
-    }
-  };
+  final static Function<List<Value>, Value> LIST_TO_VALUE = ArrayV::new;
 
-  final static Function<byte[], Value> BYTES_TO_VALUE = new Function<byte[], Value>() {
-    @Override
-    public Value apply(byte[] input) {
-      return new BytesV(input);
-    }
-  };
+  final static Function<byte[], Value> BYTES_TO_VALUE = BytesV::new;
 
   /// Unwrap functions
 
-  final static Function<TimeV, Instant> VALUE_TO_INSTANT = new Function<TimeV, Instant>() {
-    @Override
-    public Instant apply(TimeV time) {
-      return time.truncated();
-    }
-  };
+  final static Function<TimeV, Instant> VALUE_TO_INSTANT = TimeV::truncated;
 
-  final static Function<ArrayV, List<Value>> VALUE_TO_LIST = new Function<ArrayV, List<Value>>() {
-    @Override
-    public List<Value> apply(ArrayV input) {
-      return input.values;
-    }
-  };
+  final static Function<ArrayV, List<Value>> VALUE_TO_LIST = input -> input.values;
 
-  final static Function<ObjectV, Map<String, Value>> VALUE_TO_MAP = new Function<ObjectV, Map<String, Value>>() {
-    @Override
-    public Map<String, Value> apply(ObjectV input) {
-      return input.values;
-    }
-  };
+  final static Function<ObjectV, Map<String, Value>> VALUE_TO_MAP = input -> input.values;
 }

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Constructors.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Constructors.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static com.faunadb.client.types.Decoder.decodeImpl;
 import static java.lang.String.format;
@@ -114,7 +113,7 @@ final class Constructors {
 
       final Set<String> namesToRemove = new HashSet<>(Arrays.asList(names));
 
-      return Arrays.asList(properties).stream()
+      return Arrays.stream(properties)
           .filter(input -> !namesToRemove.contains(input.getName()))
           .toArray(Property[]::new);
     }
@@ -128,6 +127,7 @@ final class Constructors {
         for (Annotation annotation : annotations) {
           if (annotation.annotationType() == FaunaField.class) {
             parameterNames[i] = ((FaunaField) annotation).value();
+            break;
           }
         }
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Decoder.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Decoder.java
@@ -31,8 +31,8 @@ import static java.lang.reflect.Modifier.isAbstract;
  */
 @SuppressWarnings("unchecked")
 public final class Decoder {
-  private static final Double DOUBLE_DEFAULT = Double.valueOf(0d);
-  private static final Float FLOAT_DEFAULT = Float.valueOf(0f);
+  private static final Double DOUBLE_DEFAULT = 0d;
+  private static final Float FLOAT_DEFAULT = 0f;
 
   private Decoder() {
   }
@@ -163,9 +163,7 @@ public final class Decoder {
       }
 
       return map;
-    } catch (InstantiationException ex) {
-      return couldNotInstantiateMap(dstType, ex);
-    } catch (IllegalAccessException ex) {
+    } catch (InstantiationException | IllegalAccessException ex) {
       return couldNotInstantiateMap(dstType, ex);
     }
   }
@@ -189,9 +187,7 @@ public final class Decoder {
       }
 
       return collection;
-    } catch (InstantiationException ex) {
-      return couldNotInstantiateCollection(dstType, ex);
-    } catch (IllegalAccessException ex) {
+    } catch (InstantiationException | IllegalAccessException ex) {
       return couldNotInstantiateCollection(dstType, ex);
     }
   }

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Deserializer.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Deserializer.java
@@ -114,8 +114,7 @@ class Deserializer {
 
   static class ArrayDeserializer extends TreeDeserializer<ArrayV> {
     @Override
-    ArrayV deserializeTree(JsonNode tree, final ObjectMapper json, JsonLocation loc)
-      throws JsonParseException {
+    ArrayV deserializeTree(JsonNode tree, final ObjectMapper json, JsonLocation loc) {
 
       List<Value> values = new ArrayList<>();
 
@@ -130,8 +129,7 @@ class Deserializer {
 
   static class ObjectDeserializer extends TreeDeserializer<ObjectV> {
     @Override
-    ObjectV deserializeTree(final JsonNode tree, final ObjectMapper json, JsonLocation loc)
-      throws JsonParseException {
+    ObjectV deserializeTree(final JsonNode tree, final ObjectMapper json, JsonLocation loc) {
 
       Map<String, Value> values = new LinkedHashMap<>();
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Encoder.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Encoder.java
@@ -56,7 +56,7 @@ public final class Encoder {
     if (obj == null)
       return Value.NullV.NULL;
 
-    if (Value.class.isInstance(obj))
+    if (obj instanceof Value)
       return (Value) obj;
 
     if (contains(obj))

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Field.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Field.java
@@ -67,7 +67,7 @@ public final class Field<T> {
             return Result.fail(format("Failed to collect values: %s", String.join(", ", failures)));
           }
 
-          return Result.<List<A>>success(success);
+          return Result.success(success);
         }
       };
   }
@@ -83,7 +83,7 @@ public final class Field<T> {
 
     @Override
     public Result<Map<String, A>> decode(Value input) {
-      return input.to(OBJECT).<Map<String, A>>flatMap(toMap);
+      return input.to(OBJECT).flatMap(toMap);
     }
 
     @Override
@@ -114,7 +114,7 @@ public final class Field<T> {
             return Result.fail(format("Failed to collect values: %s", String.join(", ", failures)));
           }
 
-          return Result.<Map<String, A>>success(success);
+          return Result.success(success);
         }
       };
     }

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Field.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Field.java
@@ -260,8 +260,7 @@ public final class Field<T> {
 
   @Override
   public boolean equals(Object other) {
-    return other != null &&
-      other instanceof Field &&
+    return other instanceof Field &&
       this.path.equals(((Field) other).path);
   }
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
@@ -83,7 +83,7 @@ final class Path {
   }
 
   static Path empty() {
-    return new Path(Collections.<Segment>emptyList());
+    return new Path(Collections.emptyList());
   }
 
   static Path from(String... keys) {

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
@@ -46,15 +46,12 @@ final class Path {
 
     @Override
     public Result<Value> get(Value root) {
-      return root.to(OBJECT).flatMap(new Function<Map<String, Value>, Result<Value>>() {
-        @Override
-        public Result<Value> apply(Map<String, Value> obj) {
-          Value value = obj.get(segment);
-          if (value != null)
-            return Result.success(value);
+      return root.to(OBJECT).flatMap(obj -> {
+        Value value = obj.get(segment);
+        if (value != null)
+          return Result.success(value);
 
-          return Result.fail(format("Object key \"%s\" not found", segment));
-        }
+        return Result.fail(format("Object key \"%s\" not found", segment));
       });
     }
 
@@ -67,14 +64,11 @@ final class Path {
 
     @Override
     public Result<Value> get(Value root) {
-      return root.to(ARRAY).flatMap(new Function<List<Value>, Result<Value>>() {
-        @Override
-        public Result<Value> apply(List<Value> array) {
-          try {
-            return Result.success(array.get(segment));
-          } catch (IndexOutOfBoundsException ign) {
-            return Result.fail(format("Array index \"%s\" not found", segment));
-          }
+      return root.to(ARRAY).flatMap(array -> {
+        try {
+          return Result.success(array.get(segment));
+        } catch (IndexOutOfBoundsException ign) {
+          return Result.fail(format("Array index \"%s\" not found", segment));
         }
       });
     }

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Path.java
@@ -24,8 +24,7 @@ final class Path {
 
     @Override
     public boolean equals(Object other) {
-      return other != null &&
-        other instanceof Segment &&
+      return other instanceof Segment &&
         this.segment.equals(((Segment) other).segment);
     }
 
@@ -133,8 +132,7 @@ final class Path {
 
   @Override
   public boolean equals(Object other) {
-    return other != null &&
-      other instanceof Path &&
+    return other instanceof Path &&
       this.segments.equals(((Path) other).segments);
   }
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Result.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Result.java
@@ -55,8 +55,7 @@ public abstract class Result<T> {
 
     @Override
     public boolean equals(Object other) {
-      return other != null &&
-        other instanceof Success &&
+      return other instanceof Success &&
         this.value.equals(((Success) other).value);
     }
 
@@ -118,8 +117,7 @@ public abstract class Result<T> {
 
     @Override
     public boolean equals(Object other) {
-      return other != null &&
-        other instanceof Failure &&
+      return other instanceof Failure &&
         this.error.equals(((Failure) other).error);
     }
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Types.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Types.java
@@ -4,7 +4,6 @@ import com.faunadb.client.errors.FaunaException;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Value.java
@@ -803,7 +803,7 @@ public abstract class Value extends Expr {
 
     @Override
     public int hashCode() {
-      return value.hashCode();
+      return Arrays.hashCode(value);
     }
 
     @Override

--- a/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Value.java
+++ b/faunadb-java-dsl/src/main/java/com/faunadb/client/types/Value.java
@@ -292,7 +292,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object other) {
-      return other != null && other instanceof ScalarValue &&
+      return other instanceof ScalarValue &&
         this.value.equals(((ScalarValue) other).value);
     }
 
@@ -337,7 +337,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object other) {
-      return other != null && other instanceof ObjectV &&
+      return other instanceof ObjectV &&
         this.values.equals(((ObjectV) other).values);
     }
 
@@ -382,8 +382,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object other) {
-      return other != null
-        && other instanceof ArrayV &&
+      return other instanceof ArrayV &&
         this.values.equals(((ArrayV) other).values);
     }
 
@@ -525,8 +524,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object other) {
-      return other != null
-        && other instanceof NullV;
+      return other instanceof NullV;
     }
 
     @Override
@@ -661,7 +659,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || !(obj instanceof RefID))
+      if (!(obj instanceof RefID))
         return false;
 
       RefID other = (RefID) obj;
@@ -721,7 +719,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || !(obj instanceof RefV))
+      if (!(obj instanceof RefV))
         return false;
 
       RefV other = (RefV) obj;
@@ -799,7 +797,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object other) {
-      return other != null && other instanceof BytesV &&
+      return other instanceof BytesV &&
         Arrays.equals(this.value, ((BytesV) other).value);
     }
 
@@ -841,7 +839,7 @@ public abstract class Value extends Expr {
 
     @Override
     public boolean equals(Object obj) {
-      return obj != null && obj instanceof QueryV && lambda.equals(((QueryV)obj).lambda);
+      return obj instanceof QueryV && lambda.equals(((QueryV)obj).lambda);
     }
 
     @Override

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -278,9 +278,7 @@ public class FaunaClient implements AutoCloseable {
 
   private <V> CompletableFuture<V> handleNetworkExceptions(CompletableFuture<V> f) {
       return f.whenComplete((v, ex) -> {
-              if (ex == null) {
-                  return;
-              } else if (ex instanceof ConnectException ||
+              if (ex instanceof ConnectException ||
                          ex instanceof TimeoutException) {
                   throw new UnavailableException(ex.getMessage());
               }

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -228,9 +228,9 @@ public class FaunaClient implements AutoCloseable {
 
   private CompletableFuture<Value> performRequest(JsonNode body) {
     try {
-        return handleNetworkExceptions(connection.post("", body).thenApply(r -> handleResponse(r)));
+        return handleNetworkExceptions(connection.post("", body).thenApply(this::handleResponse));
     } catch (IOException ex) {
-        CompletableFuture<Value> oops = new CompletableFuture();
+        CompletableFuture<Value> oops = new CompletableFuture<>();
         oops.completeExceptionally(ex);
         return oops;
     }


### PR DESCRIPTION
I ended up reading through our JVM driver source this weekend, and found a bunch of small things to improve. They're mostly code modernization (using lambdas and method references when possible), but there is one real bugfix too (BytesV.hashCode was wrong). I removed a bunch of type annotations that javac can infer, a bunch of null checks before instanceof checks (instanceof subsumes a null check), replaced some bespoke cache handling code with ConcurrentMap.computeIfAbsent(), some JavaDoc fixes, etc.