### PR TITLE
Update jackson to 2.9.9 + explicitely register modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val driverVersion = "2.9.0"
 val nettyVersion = "4.1.36.Final"
-val jacksonVersion = "2.8.11"
-val jacksonDocVersion = "2.8"
+val jacksonVersion = "2.9.9"
+val jacksonDocVersion = "2.9"
 val metricsVersion = "4.1.0"
 val scalaDefaultVersion = "2.12.8"
 val scalaVersions = Seq("2.11.12", scalaDefaultVersion)

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import static com.faunadb.client.types.Codec.VALUE;
 
@@ -129,7 +130,7 @@ public class FaunaClient implements AutoCloseable {
     }
   }
 
-  private final ObjectMapper json = new ObjectMapper().findAndRegisterModules();
+  private final ObjectMapper json = new ObjectMapper().registerModule(new Jdk8Module());
   private final Connection connection;
 
   private FaunaClient(Connection connection) {

--- a/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/DeserializationSpec.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 public class DeserializationSpec {
 
@@ -30,7 +31,7 @@ public class DeserializationSpec {
 
   @Before
   public void setUp() throws Exception {
-    json = new ObjectMapper().findAndRegisterModules();
+    json = new ObjectMapper().registerModule(new Jdk8Module());
   }
 
   @Test

--- a/faunadb-java/src/test/java/com/faunadb/client/ObjectCodecSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ObjectCodecSpec.java
@@ -21,6 +21,7 @@ import static com.faunadb.client.types.Codec.STRING;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 public class ObjectCodecSpec {
 
@@ -61,7 +62,7 @@ public class ObjectCodecSpec {
 
   @Before
   public void setUp() throws Exception {
-    json = new ObjectMapper().findAndRegisterModules();
+    json = new ObjectMapper().registerModule(new Jdk8Module());
   }
 
   @Test


### PR DESCRIPTION
Explicit registration is recommended to avoid runtime failures - https://github.com/FasterXML/jackson-modules-java8#registering-modules