### PR TITLE
DRV-117: [scala] Unclutter query methods implementation in FaunaClient

### DIFF
--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,7 +1,7 @@
 package faunadb
 
 import com.codahale.metrics.MetricRegistry
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.faunadb.common.Connection
@@ -19,7 +19,6 @@ import io.netty.handler.codec.http.FullHttpResponse
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.control.NonFatal
 
 /** Companion object to the FaunaClient class. */
 object FaunaClient {
@@ -95,16 +94,23 @@ class FaunaClient private (connection: Connection) {
     *         [[faunadb.values.Field]] API. If the query fails, failed
     *         future is returned.
     */
-  def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] =
-    connection.post("", json.valueToTree(expr)).toScala.map { resp =>
-      try {
-        handleQueryErrors(resp)
-        val rv = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        if (rv eq null) NullV else rv
-      } finally {
-        resp.release()
+  def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] = {
+    def handleSuccessResponse(response: FullHttpResponse): Future[Value] = Future {
+      val rv = json.treeToValue[Value](parseResponseBody(response).get("resource"), classOf[Value])
+      if (rv eq null) NullV else rv
+    }.andThen {
+      case _ => response.release()
+    }
+
+    val response = connection.post("", json.valueToTree(expr)).toScala
+
+    response
+      .flatMap {
+        case successResponse if successResponse.status().code() < 300 => handleSuccessResponse(successResponse)
+        case errorResponse => handleErrorResponse(errorResponse)
       }
-    }.recover(handleNetworkExceptions)
+      .recoverWith(handleNetworkExceptions)
+  }
 
   /**
     * Issues multiple queries as a single transaction.
@@ -116,16 +122,23 @@ class FaunaClient private (connection: Connection) {
     *         value using the [[faunadb.values.Field]] API. If *any*
     *         query fails, a failed future is returned.
     */
-  def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
-    connection.post("", json.valueToTree(exprs)).toScala.map { resp =>
-      try {
-        handleQueryErrors(resp)
-        val arr = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        arr.asInstanceOf[ArrayV].elems
-      } finally {
-        resp.release()
+  def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] = {
+    def handleSuccessResponse(response: FullHttpResponse): Future[IndexedSeq[Value]] = Future {
+      val arr = json.treeToValue[Value](parseResponseBody(response).get("resource"), classOf[Value])
+      arr.asInstanceOf[ArrayV].elems
+    }.andThen {
+      case _ => response.release()
+    }
+
+    val response = connection.post("", json.valueToTree(exprs)).toScala
+
+    response
+      .flatMap {
+        case successResponse if successResponse.status().code() < 300 => handleSuccessResponse(successResponse)
+        case errorResponse => handleErrorResponse(errorResponse)
       }
-    }.recover(handleNetworkExceptions)
+      .recoverWith(handleNetworkExceptions)
+  }
 
   /**
     * Creates a new scope to execute session queries. Queries submitted within the session scope will be
@@ -169,47 +182,45 @@ class FaunaClient private (connection: Connection) {
   def syncLastTxnTime(timestamp: Long): Unit =
     connection.syncLastTxnTime(timestamp)
 
-  private def handleNetworkExceptions[A]: PartialFunction[Throwable, A] = {
-    case ex: ConnectException =>
-      throw new UnavailableException(ex.getMessage, ex)
-    case ex: TimeoutException =>
-      throw new TimeoutException(ex.getMessage)
+  private def handleNetworkExceptions[A]: PartialFunction[Throwable, Future[A]] = {
+    case ex: ConnectException => Future.failed(new UnavailableException(ex.getMessage, ex))
+    case ex: TimeoutException => Future.failed(new TimeoutException(ex.getMessage))
   }
 
-  private def handleQueryErrors(response: FullHttpResponse) =
-    response.status().code() match {
-      case x if x >= 300 =>
-        try {
-          val errors = parseResponseBody(response).get("errors").asInstanceOf[ArrayNode]
-          val parsedErrors = if (errors != null) {
-            errors.iterator().asScala.map {
-              json.treeToValue(_, classOf[QueryError])
-            }
-          } else {
-            Seq.empty[QueryError]
-          }
-
-          val error = QueryErrorResponse(x, parsedErrors.toIndexedSeq)
-          x match {
-            case 400 => throw new BadRequestException(error)
-            case 401 => throw new UnauthorizedException(error)
-            case 403 => throw new PermissionDeniedException(error)
-            case 404 => throw new NotFoundException(error)
-            case 500 => throw new InternalException(error)
-            case 503 => throw new UnavailableException(error)
-            case _   => throw new UnknownException(error)
-          }
-        } catch {
-          case e: FaunaException => throw e
-          case NonFatal(ex)      => response.status().code() match {
-            case 503   => throw new UnavailableException("Service Unavailable: Unparseable response.", ex)
-            case s @ _ => throw new UnknownException(s"Unparseable service $s response.", ex)
-          }
-        }
-      case _ =>
+  private def handleErrorResponse(response: FullHttpResponse)(implicit ec: ExecutionContext): Future[Nothing] = {
+    def parseError(): Future[QueryErrorResponse] = Future {
+      val statusCode = response.status().code()
+      val errors = Option(parseResponseBody(response).get("errors").asInstanceOf[ArrayNode])
+      val parsedErrors = errors.map(_.iterator().asScala.map(json.treeToValue(_, classOf[QueryError])).toIndexedSeq).getOrElse(IndexedSeq.empty)
+      val error = QueryErrorResponse(statusCode, parsedErrors)
+      error
+    }.recoverWith {
+      case e: FaunaException => Future.failed(e)
+      case unavailable if response.status().code() == 503 => Future.failed(new UnavailableException("Service Unavailable: Unparseable response.", unavailable))
+      case unknown => Future.failed(new UnknownException(s"Unparseable service $unknown response.", unknown))
+    }.andThen {
+      case _ => response.release()
     }
 
-  private def parseResponseBody(response: FullHttpResponse) = {
+    def parseErrorAndFailWith(fun: QueryErrorResponse => FaunaException): Future[Nothing] = {
+      parseError().flatMap { errors =>
+        val exception = fun(errors)
+        Future.failed(exception)
+      }
+    }
+
+    response.status().code() match {
+      case 400 => parseErrorAndFailWith(new BadRequestException(_))
+      case 401 => parseErrorAndFailWith(new UnauthorizedException(_))
+      case 403 => parseErrorAndFailWith(new PermissionDeniedException(_))
+      case 404 => parseErrorAndFailWith(new NotFoundException(_))
+      case 500 => parseErrorAndFailWith(new InternalException(_))
+      case 503 => parseErrorAndFailWith(new UnavailableException(_))
+      case _   => parseErrorAndFailWith(new UnknownException(_))
+    }
+  }
+
+  private def parseResponseBody(response: FullHttpResponse): JsonNode = {
     val body = json.readTree(new ByteBufInputStream(response.content()))
     if (body eq null) {
       throw new IOException("Invalid JSON.")


### PR DESCRIPTION
[DRV-117](https://faunadb.atlassian.net/browse/DRV-117)

This part of an old PR I had some time ago for the old private repo. Essentially, it refactors the implementation from an imperative to a more functional style.

I'll be updating this code as well as part of [DRV-87](https://faunadb.atlassian.net/browse/DRV-87), so I thought it was a good opportunity to get these changes in first!