### PR TITLE
DRV-87: [scala] Add client-specified query timeout (implicit alternative)

### DIFF
--- a/docs/scala.md
+++ b/docs/scala.md
@@ -130,6 +130,18 @@ The `query` method takes an `Expr` object. `Expr` objects can be composed with o
     System.out.println("Hippo Spells:\n " + readHippoResults + "\n");
 ```
 
+The `query` method also accepts a `timeout` implicit parameter. The `timeout` value defines the maximum time a `query` will be allowed to run on the server. If the value is exceeded, the query is aborted. If no `timeout` is defined in scope, a default value is assigned on the server side.
+
+```scala
+import scala.concurrent.duration._
+
+implicit val timeout = 500 millis
+
+client.query(
+  Select(Value("data"), Get(hippoRef))
+)
+```
+
 ### How to retrieve the values from a query result
 
 That query returns the data in the form of a json object. It's possible to convert `Value` class to its primitive correspondent using `to` methods specifying a type.  For example the data can be extracted from the results by using:

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,7 +1,7 @@
 package faunadb
 
 import com.codahale.metrics.MetricRegistry
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.faunadb.common.Connection
@@ -17,8 +17,10 @@ import io.netty.buffer.ByteBufInputStream
 import io.netty.handler.codec.http.FullHttpResponse
 
 import scala.collection.JavaConverters._
+import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
@@ -28,22 +30,24 @@ object FaunaClient {
   /**
     * Creates a new FaunaDB client.
     *
-    *
-    *
     * @param secret The secret material of the auth key used. See [[https://fauna.com/documentation#authentication-key_access]]
     * @param endpoint URL of the FaunaDB service to connect to. Defaults to https://db.fauna.com
     * @param metrics An optional [[com.codahale.metrics.MetricRegistry]] to record stats.
+    * @param queryTimeout An optional global timeout for all the queries issued by this client. The timeout value has
+    *                     milliseconds precision. If not provided, a default timeout value is set on the server side.
     * @return A configured FaunaClient instance.
     */
   def apply(
     secret: String = null,
     endpoint: String = null,
-    metrics: MetricRegistry = null): FaunaClient = {
+    metrics: MetricRegistry = null,
+    queryTimeout: FiniteDuration = null): FaunaClient = {
 
     val b = Connection.builder
     if (endpoint ne null) b.withFaunaRoot(endpoint)
     if (secret ne null) b.withAuthToken(secret)
     if (metrics ne null) b.withMetrics(metrics)
+    if (queryTimeout ne null) b.withQueryTimeout(queryTimeout.toJava)
     b.withJvmDriver(JvmDriver.SCALA)
 
     new FaunaClient(b.build)
@@ -90,39 +94,46 @@ class FaunaClient private (connection: Connection) {
     * Issues a query.
     *
     * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+    * @param ec the [[scala.concurrent.ExecutionContext]] what will be used to run this query
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+    *                milliseconds precision.
     * @return A [[scala.concurrent.Future]] containing the query result.
     *         The result is an instance of [[faunadb.values.Result]],
     *         which can be cast to a typed value using the
     *         [[faunadb.values.Field]] API. If the query fails, failed
     *         future is returned.
     */
-  def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] =
-    connection.post("", json.valueToTree(expr), None.asJava).toScala.map { resp =>
-      try {
-        handleQueryErrors(resp)
-        val rv = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        if (rv eq null) NullV else rv
-      } finally {
-        resp.release()
-      }
-    }.recover(handleNetworkExceptions)
+  def query(expr: Expr)(implicit ec: ExecutionContext, timeout: FiniteDuration = null): Future[Value] =
+    performRequest(json.valueToTree(expr), Option(timeout)).map { result =>
+      if (result eq null) NullV else result
+    }
 
   /**
     * Issues multiple queries as a single transaction.
     *
     * @param exprs the queries to run.
+    * @param ec the [[scala.concurrent.ExecutionContext]] what will be used to run this query
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any, for the scope of this query. The timeout value
+    *                has milliseconds precision.
     * @return A [[scala.concurrent.Future]] containing an IndexedSeq of
     *         the results of each query. Each result is an instance of
     *         [[faunadb.values.Value]], which can be cast to a typed
     *         value using the [[faunadb.values.Field]] API. If *any*
     *         query fails, a failed future is returned.
     */
-  def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
-    connection.post("", json.valueToTree(exprs), None.asJava).toScala.map { resp =>
+  def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext, timeout: FiniteDuration = null): Future[IndexedSeq[Value]] =
+    performRequest(json.valueToTree(exprs), Option(timeout)).map { result =>
+      result.asInstanceOf[ArrayV].elems
+    }
+
+  private def performRequest(body: JsonNode, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] =
+    connection.post("", body, timeout.map(_.toJava).asJava).toScala.map { resp =>
       try {
         handleQueryErrors(resp)
-        val arr = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        arr.asInstanceOf[ArrayV].elems
+        val rv = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
+        if (rv eq null) NullV else rv
       } finally {
         resp.release()
       }


### PR DESCRIPTION
[DRV-87](https://faunadb.atlassian.net/browse/DRV-87)

### TL;DR

The `FaunaClient.query` method accepts now an implicit `timeout` parameter:

```
import scala.concurrent.duration._

implicit val timeout: FiniteDuration = 500 millis

client.query(
  Get(Ref(Collection("users"), "263608813107544596"))
)
```

If no implicit instance of `FiniteDuration` can be found in scope, the timeout parameter is simply omitted:

```
client.query(
  Get(Ref(Collection("users"), "263608813107544596"))
)
```

> NOTE: For other alternative API implementation, which defines the `timeout` parameter explicitly by overloading the `query` method, see  #212.

## Implementation details

### Why implicit?

I decided to define the `timeout` as an implicit parameter, since I consider it as part of the _context_ for running the query.  Essentially, it's not part of the _query_ itself, but it's a _configuration_ which specifies how long the query is supposed to run in the server. This falls into the category of parameters that could be defined implicitly, resulting in a more idiomatic API.

For example, this is also how Akka defines its `Timeout` parameter in the [Ask Pattern](https://doc.akka.io/api/akka/2.0.5/akka/pattern/package.html):

```
def ask(message: Any)(implicit timeout: Timeout, sender: ActorRef = Actor.noSender): Future[Any] = ???
```

For a comprehensive explanation on the motivations behind implicit parameters, you can check the following talk: [What to Leave Implicit by Martin Odersky](https://www.youtube.com/watch?v=Oij5V7LQJsA).

### Why Magnet Pattern?

In order the `timeout` parameter to be implicit and work as described above, we need to do two things: overload the `query` method, and assign a default value to the `timeout` parameter.

Unfortunately, when trying do so, we face the limitations of Scala's _native_ overloading features.

Below, there are a couple of examples:

**Example A:**

```
def query(value: Expr): Future[Value] = ???

def query(value: Expr)(implicit timeout: FiniteDuration): Future[Value] = ???
```

results in:

```
... ambiguous reference to overloaded definition,
both method query in class FaunaClient of type (value: Expr)(implicit timeout: scala.concurrent.duration.FiniteDuration)scala.concurrent.Future[Value]
and  method query in class FaunaClient of type (value: Expr)scala.concurrent.Future[Value]
match argument types (Expr)
  client.query(Expr(""))
```

**Example B:**

```
def query(value: Expr)(implicit timeout: FiniteDuration = null): Future[Value] = ???

def query(value: Seq[Expr])(implicit timeout: FiniteDuration = null): Future[Value] = ???
```

results in:

```
... multiple overloaded alternatives of method query define default arguments.
```

In order to overcome these limitations, the _Magnet Pattern_ is commonly used.

In a nutshell, the Magnet Pattern defines a _magnet companion object_ containing a series of implicit conversions (or _magnet branches_) which represent the different ways the desired method is overloaded. Then, the method itself is defined only once with a single parameter: the magnet. When passing parameters to the method, the proper branch is picked up automatically thanks to the implicit conversions defined in the _magnet companion_.

For a comprehensive explanation on the Magnet Pattern, I recommend checking out the following post: [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/).

#### Magnet Pattern Drawbacks

Although the Magnet Pattern helps us to overcome Scala's overloading limitations and define the `timeout` parameter implicitly, there are some caveats when using it.

The main drawback (at least for our case) is that, in a way, it _obfuscates_ the API. Since the parameters and the return type of the overloading alternatives are pushed into the magnet companion, users cannot tell which ones those should be just by simply checking the method signature.

Because of this reason, I extended the Scaladoc for the `query` method with further explanations and examples.

On the bright side, users might be also already familiar with the Magnet Pattern since it is widely used in [Akka HTTP's Routing DSL](https://doc.akka.io/docs/akka-http/current/introduction.html#routing-dsl-for-http-servers). This comes from a long time, when it was formerly known as [Spray](http://spray.io/).

### Other alternatives

Below there are some other alternatives I've also considered but didn't feel as idiomatic and pleasant to consume as a user.

#### Basic overloading

API:

```
def query(value: Expr): Future[Value] = ???

def query(value: Expr, timeout: FiniteDuration): Future[Value] = ???
```

Usage:

```
import scala.concurrent.duration._

val timeout: FiniteDuration = 500 millis

client.query(
  Get(Ref(Collection("users"), "263608813107544596")),
  timeout
)
```

#### Option param

API:

```
def query(value: Expr, timeout: Option[FiniteDuration] = None): Future[Value] = ???
```

Usage:

```
import scala.concurrent.duration._

val timeout: FiniteDuration = 500 millis

client.query(
  Get(Ref(Collection("users"), "263608813107544596")),
  Some(timeout)
)
```

#### Currying

API:

```
def query(value: Expr): Future[Value] = ???

def query(timeout: FiniteDuration)(value: Expr): Future[Value] = ???
```

Usage:

```
import scala.concurrent.duration._

val timeout: FiniteDuration = 500 millis

client.query(timeout)(
  Get(Ref(Collection("users"), "263608813107544596"))
)
```