### PR TITLE
DRV-87: [scala] Add client-specified query timeout (overloading alternative)

### DIFF
--- a/docs/scala.md
+++ b/docs/scala.md
@@ -130,6 +130,19 @@ The `query` method takes an `Expr` object. `Expr` objects can be composed with o
     System.out.println("Hippo Spells:\n " + readHippoResults + "\n");
 ```
 
+The `query` method also accepts a `timeout` parameter. The `timeout` value defines the maximum time a `query` will be allowed to run on the server. If the value is exceeded, the query is aborted. If no `timeout` is defined in scope, a default value is assigned on the server side.
+
+```scala
+import scala.concurrent.duration._
+
+val timeout = 500 millis
+
+client.query(
+  Select(Value("data"), Get(hippoRef)),
+  timeout
+)
+```
+
 ### How to retrieve the values from a query result
 
 That query returns the data in the form of a json object. It's possible to convert `Value` class to its primitive correspondent using `to` methods specifying a type.  For example the data can be extracted from the results by using:

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,7 +1,7 @@
 package faunadb
 
 import com.codahale.metrics.MetricRegistry
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.faunadb.common.Connection
@@ -17,8 +17,10 @@ import io.netty.buffer.ByteBufInputStream
 import io.netty.handler.codec.http.FullHttpResponse
 
 import scala.collection.JavaConverters._
+import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
@@ -28,22 +30,24 @@ object FaunaClient {
   /**
     * Creates a new FaunaDB client.
     *
-    *
-    *
     * @param secret The secret material of the auth key used. See [[https://fauna.com/documentation#authentication-key_access]]
     * @param endpoint URL of the FaunaDB service to connect to. Defaults to https://db.fauna.com
     * @param metrics An optional [[com.codahale.metrics.MetricRegistry]] to record stats.
+    * @param queryTimeout An optional global timeout for all the queries issued by this client. The timeout value has
+    *                     milliseconds precision. If not provided, a default timeout value is set on the server side.
     * @return A configured FaunaClient instance.
     */
   def apply(
     secret: String = null,
     endpoint: String = null,
-    metrics: MetricRegistry = null): FaunaClient = {
+    metrics: MetricRegistry = null,
+    queryTimeout: FiniteDuration = null): FaunaClient = {
 
     val b = Connection.builder
     if (endpoint ne null) b.withFaunaRoot(endpoint)
     if (secret ne null) b.withAuthToken(secret)
     if (metrics ne null) b.withMetrics(metrics)
+    if (queryTimeout ne null) b.withQueryTimeout(queryTimeout.toJava)
     b.withJvmDriver(JvmDriver.SCALA)
 
     new FaunaClient(b.build)
@@ -90,27 +94,55 @@ class FaunaClient private (connection: Connection) {
     * Issues a query.
     *
     * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
     * @return A [[scala.concurrent.Future]] containing the query result.
     *         The result is an instance of [[faunadb.values.Result]],
     *         which can be cast to a typed value using the
     *         [[faunadb.values.Field]] API. If the query fails, failed
     *         future is returned.
     */
-  def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] =
-    connection.post("", json.valueToTree(expr), None.asJava).toScala.map { resp =>
-      try {
-        handleQueryErrors(resp)
-        val rv = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        if (rv eq null) NullV else rv
-      } finally {
-        resp.release()
-      }
-    }.recover(handleNetworkExceptions)
+  def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] = query(expr, None)
+
+  /**
+    * Issues a query.
+    *
+    * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+    *                milliseconds precision.
+    * @return A [[scala.concurrent.Future]] containing the query result.
+    *         The result is an instance of [[faunadb.values.Result]],
+    *         which can be cast to a typed value using the
+    *         [[faunadb.values.Field]] API. If the query fails, failed
+    *         future is returned.
+    */
+  def query(expr: Expr, timeout: FiniteDuration)(implicit ec: ExecutionContext): Future[Value] = query(expr, Some(timeout))
+
+  /**
+    * Issues a query.
+    *
+    * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+    *                milliseconds precision.
+    * @return A [[scala.concurrent.Future]] containing the query result.
+    *         The result is an instance of [[faunadb.values.Result]],
+    *         which can be cast to a typed value using the
+    *         [[faunadb.values.Field]] API. If the query fails, failed
+    *         future is returned.
+    */
+  def query(expr: Expr, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] =
+    performRequest(json.valueToTree(expr), timeout).map { result =>
+      if (result eq null) NullV else result
+    }
 
   /**
     * Issues multiple queries as a single transaction.
     *
     * @param exprs the queries to run.
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
     * @return A [[scala.concurrent.Future]] containing an IndexedSeq of
     *         the results of each query. Each result is an instance of
     *         [[faunadb.values.Value]], which can be cast to a typed
@@ -118,11 +150,50 @@ class FaunaClient private (connection: Connection) {
     *         query fails, a failed future is returned.
     */
   def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
-    connection.post("", json.valueToTree(exprs), None.asJava).toScala.map { resp =>
+    query(exprs, None)
+
+  /**
+    * Issues multiple queries as a single transaction.
+    *
+    * @param exprs the queries to run.
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any, for the scope of this query. The timeout value
+    *                has milliseconds precision.
+    * @return A [[scala.concurrent.Future]] containing an IndexedSeq of
+    *         the results of each query. Each result is an instance of
+    *         [[faunadb.values.Value]], which can be cast to a typed
+    *         value using the [[faunadb.values.Field]] API. If *any*
+    *         query fails, a failed future is returned.
+    */
+  def query(exprs: Iterable[Expr], timeout: FiniteDuration)(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
+    query(exprs, Some(timeout))
+
+  /**
+    * Issues multiple queries as a single transaction.
+    *
+    * @param exprs the queries to run.
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any, for the scope of this query. The timeout value
+    *                has milliseconds precision.
+    * @return A [[scala.concurrent.Future]] containing an IndexedSeq of
+    *         the results of each query. Each result is an instance of
+    *         [[faunadb.values.Value]], which can be cast to a typed
+    *         value using the [[faunadb.values.Field]] API. If *any*
+    *         query fails, a failed future is returned.
+    */
+  def query(exprs: Iterable[Expr], timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
+    performRequest(json.valueToTree(exprs), timeout).map { result =>
+      result.asInstanceOf[ArrayV].elems
+    }
+
+  private def performRequest(body: JsonNode, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] =
+    connection.post("", body, timeout.map(_.toJava).asJava).toScala.map { resp =>
       try {
         handleQueryErrors(resp)
-        val arr = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
-        arr.asInstanceOf[ArrayV].elems
+        val result = json.treeToValue[Value](parseResponseBody(resp).get("resource"), classOf[Value])
+        result
       } finally {
         resp.release()
       }

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -1,6 +1,6 @@
 package faunadb
 
-import faunadb.errors.{ BadRequestException, NotFoundException, PermissionDeniedException, UnauthorizedException }
+import faunadb.errors.{ BadRequestException, NotFoundException, PermissionDeniedException, UnauthorizedException, UnavailableException }
 import faunadb.query.TimeUnit
 import faunadb.query._
 import faunadb.values._
@@ -119,6 +119,12 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "echo values" in {
     await(client.query(ObjectV("foo" -> StringV("bar")))) should equal (ObjectV("foo" -> StringV("bar")))
     await(client.query("qux")) should equal (StringV("qux"))
+  }
+
+  it should "fail with timeout error" in {
+    val timeout = Duration.Zero
+    val thrown = the [UnavailableException] thrownBy await(client.query("echo", timeout))
+    thrown.message should include ("time out: Read timed out.")
   }
 
   it should "fail with permission denied" in {


### PR DESCRIPTION
[DRV-87](https://faunadb.atlassian.net/browse/DRV-87)

The `FaunaClient.query` method has been overloaded as follows:

```
def query(expr: Expr)(implicit ec: ExecutionContext): Future[Value] = query(expr, None)

def query(expr: Expr, timeout: FiniteDuration)(implicit ec: ExecutionContext): Future[Value] = ???

def query(expr: Expr, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] = ???

def query(exprs: Iterable[Expr])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =

def query(exprs: Iterable[Expr], timeout: FiniteDuration)(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] = ???

def query(exprs: Iterable[Expr], timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] = ???
```

> NOTE: For other alternative API implementation, which defines the `timeout` parameter implicilty using the _Magnet Pattern_, see #211.