### PR TITLE
DRV-206: [scala] Use ScalaFutures in ClientSpec

### DIFF
--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -1,18 +1,23 @@
 package faunadb
 
-import faunadb.errors.{ BadRequestException, NotFoundException, PermissionDeniedException, UnauthorizedException, UnavailableException }
-import faunadb.query.TimeUnit
-import faunadb.query._
+import faunadb.errors._
+import faunadb.query.{ TimeUnit, _ }
 import faunadb.values._
-import java.time.{ Instant, LocalDate }
 import java.time.temporal.ChronoUnit
+import java.time.{ Instant, LocalDate }
+import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.{ BeforeAndAfterAll, FlatSpec, Matchers }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 import scala.util.Random
 
-class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class ClientSpec
+    extends FlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with IntegrationPatience {
+
   val config = {
     val rootKey = Option(System.getenv("FAUNA_ROOT_KEY")) getOrElse {
       throw new RuntimeException("FAUNA_ROOT_KEY must defined to run tests")
@@ -26,7 +31,12 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   val rootClient = FaunaClient(endpoint = config("root_url"), secret = config("root_token"))
 
-  val testDbName = "faunadb-scala-test"
+  val testDbName = {
+    val now = Instant.now()
+    val timeSuffix = now.truncatedTo(ChronoUnit.SECONDS).toString.replace(":", ".")
+    val randomSuffix = aRandomString(10)
+    s"faunadb-scala-test-$timeSuffix-$randomSuffix"
+  }
   var client: FaunaClient = null
   var adminClient: FaunaClient = null
 
@@ -49,35 +59,30 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   val PageEvents = DataField.collect(EventField)
   val PageRefs = DataField.to[Seq[RefV]]
 
-  def await[T](f: Future[T]) = Await.result(f, 5.second)
-  def ready[T](f: Future[T]) = Await.ready(f, 5.second)
-
   def aRandomString: String = aRandomString(size = 8)
   def aRandomString(size: Int): String = Random.alphanumeric.take(size).mkString
 
   def dropDB(): Unit =
-    ready(rootClient.query(Delete(Database(testDbName))))
+    rootClient.query(Delete(Database(testDbName))).futureValue
 
   // tests
 
   override protected def beforeAll(): Unit = {
-    dropDB()
-
-    val db = await(rootClient.query(CreateDatabase(Obj("name" -> testDbName))))
+    val db = rootClient.query(CreateDatabase(Obj("name" -> testDbName))).futureValue
     val dbRef = db(RefField).get
-    val serverKey = await(rootClient.query(CreateKey(Obj("database" -> dbRef, "role" -> "server"))))
-    val adminKey = await(rootClient.query(CreateKey(Obj("database" -> dbRef, "role" -> "admin"))))
+    val serverKey = rootClient.query(CreateKey(Obj("database" -> dbRef, "role" -> "server"))).futureValue
+    val adminKey = rootClient.query(CreateKey(Obj("database" -> dbRef, "role" -> "admin"))).futureValue
 
     client = FaunaClient(endpoint = config("root_url"), secret = serverKey(SecretField).get)
     adminClient = FaunaClient(endpoint = config("root_url"), secret = adminKey(SecretField).get)
 
-    await(client.query(CreateCollection(Obj("name" -> "spells"))))
+    client.query(CreateCollection(Obj("name" -> "spells"))).futureValue
 
-    await(client.query(CreateIndex(Obj(
+    client.query(CreateIndex(Obj(
       "name" -> "spells_by_element",
       "source" -> Collection("spells"),
       "terms" -> Arr(Obj("field" -> Arr("data", "element"))),
-      "active" -> true))))
+      "active" -> true))).futureValue
   }
 
   override protected def afterAll(): Unit = {
@@ -90,10 +95,10 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "parse nested sets" in {
     val collName = aRandomString
     val indexName = aRandomString
-    await(client.query(CreateCollection(Obj("name" -> collName))))
-    await(client.query(CreateIndex(Obj("name" -> indexName, "source" -> Collection(collName), "active" -> true))))
+    client.query(CreateCollection(Obj("name" -> collName))).futureValue
+    client.query(CreateIndex(Obj("name" -> indexName, "source" -> Collection(collName), "active" -> true))).futureValue
 
-    val result = await(client.query(
+    val result = client.query(
       Map(
         Arr(
           Match(Index(indexName))
@@ -103,58 +108,59 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
           Obj( "value" -> Var("x"), "IsSet" -> IsSet(Var("x")))
         )
       )
-    ))
+    ).futureValue
 
     result shouldBe ArrayV(ObjectV("value" -> SetRefV(ObjectV("match" -> RefV(indexName, Native.Indexes))), "IsSet" -> TrueV))
   }
 
   "Fauna Client" should "should not find an instance" in {
-    a[NotFoundException] should be thrownBy await(client.query(Get(RefV("1234", RefV("spells", Native.Collections)))))
+    client.query(Get(RefV("1234", RefV("spells", Native.Collections)))).failed.futureValue shouldBe a[NotFoundException]
   }
 
   it should "abort the execution" in {
-    a[BadRequestException] should be thrownBy await(client.query(Abort("a message")))
+    client.query(Abort("a message")).failed.futureValue shouldBe a[BadRequestException]
   }
 
   it should "echo values" in {
-    await(client.query(ObjectV("foo" -> StringV("bar")))) should equal (ObjectV("foo" -> StringV("bar")))
-    await(client.query("qux")) should equal (StringV("qux"))
+    client.query(ObjectV("foo" -> StringV("bar"))).futureValue should equal (ObjectV("foo" -> StringV("bar")))
+    client.query("qux").futureValue should equal (StringV("qux"))
   }
 
   it should "fail with timeout error" in {
     val timeout = Duration.Zero
-    val thrown = the [UnavailableException] thrownBy await(client.query("echo", timeout))
-    thrown.message should include ("time out: Read timed out.")
+    val thrown = client.query("echo", timeout).failed.futureValue
+    thrown shouldBe an[UnavailableException]
+    thrown.getMessage should include ("time out: Read timed out.")
   }
 
   it should "fail with permission denied" in {
-    val key = await(rootClient.query(CreateKey(Obj("database" -> Database(testDbName), "role" -> "client"))))
+    val key = rootClient.query(CreateKey(Obj("database" -> Database(testDbName), "role" -> "client"))).futureValue
     val client = FaunaClient(endpoint = config("root_url"), secret = key(SecretField).get)
 
-    an[PermissionDeniedException] should be thrownBy await(client.query(Paginate(Native.Databases)))
+    client.query(Paginate(Native.Databases)).failed.futureValue shouldBe a[PermissionDeniedException]
   }
 
   it should "fail with unauthorized" in {
     val badClient = FaunaClient(endpoint = config("root_url"), secret = "notavalidsecret")
-    an[UnauthorizedException] should be thrownBy await(badClient.query(Get(RefV("12345", RefV("spells", Native.Collections)))))
+    badClient.query(Get(RefV("12345", RefV("spells", Native.Collections)))).failed.futureValue shouldBe an[UnauthorizedException]
   }
 
   it should "receive a Null value properly" in {
-    await(client.query(NullV)) shouldBe NullV
+    client.query(NullV).futureValue shouldBe NullV
   }
 
   it should "create a new instance" in {
-    val inst = await(client.query(
+    val inst = client.query(
       Create(Collection("spells"),
-        Obj("data" -> Obj("testField" -> "testValue")))))
+        Obj("data" -> Obj("testField" -> "testValue")))).futureValue
 
     inst(RefField).get.collection should equal (Some(RefV("spells", Native.Collections)))
     inst(RefField).get.database should be (None)
     inst("data", "testField").to[String].get should equal ("testValue")
 
-    await(client.query(Exists(inst(RefField)))) should equal (TrueV)
+    client.query(Exists(inst(RefField))).futureValue should equal (TrueV)
 
-    val inst2 = await(client.query(Create(Collection("spells"),
+    val inst2 = client.query(Create(Collection("spells"),
       Obj("data" -> Obj(
         "testData" -> Obj(
           "array" -> Arr(1, "2", 3.4),
@@ -162,7 +168,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
           "num" -> 1234,
           "string" -> "sup",
           "float" -> 1.234,
-          "null" -> NullV))))))
+          "null" -> NullV))))).futureValue
 
     val testData = inst2("data", "testData")
 
@@ -181,7 +187,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val expr1 = Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText1)))
     val expr2 = Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText2)))
 
-    val results = await(client.query(Seq(expr1, expr2)))
+    val results = client.query(Seq(expr1, expr2)).futureValue
 
     results.length shouldBe 2
     results(0)("data", "queryTest1").to[String].get shouldBe randomText1
@@ -190,71 +196,64 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "get at timestamp" in {
     val randomCollectionName = aRandomString
-    val randomCollection = await(client.query(CreateCollection(Obj("name" -> randomCollectionName))))
+    val randomCollection = client.query(CreateCollection(Obj("name" -> randomCollectionName))).futureValue
 
-    val data = await(client.query(Create(randomCollection(RefField).get, Obj("data" -> Obj("x" -> 1)))))
+    val data = client.query(Create(randomCollection(RefField).get, Obj("data" -> Obj("x" -> 1)))).futureValue
     val dataRef = data(RefField).get
 
     val ts1 = data(TsField).get
-    val ts2 = await(client.query(Update(dataRef, Obj("data" -> Obj("x" -> 2)))))(TsField).get
-    val ts3 = await(client.query(Update(dataRef, Obj("data" -> Obj("x" -> 3)))))(TsField).get
+    val ts2 = (client.query(Update(dataRef, Obj("data" -> Obj("x" -> 2)))).futureValue).apply(TsField).get
+    val ts3 = (client.query(Update(dataRef, Obj("data" -> Obj("x" -> 3)))).futureValue).apply(TsField).get
 
     val xField = Field("data", "x").to[Long]
 
-    await(client.query(At(ts1, Get(dataRef))))(xField).get should equal(1)
-    await(client.query(At(ts2, Get(dataRef))))(xField).get should equal(2)
-    await(client.query(At(ts3, Get(dataRef))))(xField).get should equal(3)
+    (client.query(At(ts1, Get(dataRef))).futureValue).apply(xField).get should equal(1)
+    (client.query(At(ts2, Get(dataRef))).futureValue).apply(xField).get should equal(2)
+    (client.query(At(ts3, Get(dataRef))).futureValue).apply(xField).get should equal(3)
   }
 
   it should "issue a paginated query" in {
     val randomCollectionName = aRandomString
-    val randomCollectionF = client.query(CreateCollection(Obj("name" -> randomCollectionName)))
-    val collectionRef = await(randomCollectionF)(RefField).get
+    val randomCollection = client.query(CreateCollection(Obj("name" -> randomCollectionName))).futureValue
+    val collectionRef = randomCollection(RefField)
 
-    val randomCollectionIndexF = client.query(CreateIndex(Obj(
+    val randomCollectionIndexResult = client.query(CreateIndex(Obj(
       "name" -> (randomCollectionName + "_collection_index"),
       "source" -> collectionRef,
       "active" -> true,
       "unique" -> false
-    )))
+    ))).futureValue
 
-    val indexCreateF = client.query(CreateIndex(Obj(
+    val indexCreate = client.query(CreateIndex(Obj(
       "name" -> (randomCollectionName + "_test_index"),
       "source" -> collectionRef,
       "terms" -> Arr(Obj("field" -> Arr("data", "queryTest1"))),
       "active" -> true,
       "unique" -> false
-    )))
+    ))).futureValue
 
-    val randomCollectionIndex = await(randomCollectionIndexF)(RefField).get
-    val testIndex = await(indexCreateF)(RefField).get
+    val randomCollectionIndex = randomCollectionIndexResult(RefField).get
+    val testIndex = indexCreate(RefField).get
 
     val randomText1 = aRandomString
     val randomText2 = aRandomString
     val randomText3 = aRandomString
 
-    val createFuture = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText1))))
-    val createFuture2 = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText2))))
-    val createFuture3 = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText3))))
+    val create1 = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText1)))).futureValue
+    val create2 = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText2)))).futureValue
+    val create3 = client.query(Create(collectionRef, Obj("data" -> Obj("queryTest1" -> randomText3)))).futureValue
 
-    val create1 = await(createFuture)
-    val create2 = await(createFuture2)
-    val create3 = await(createFuture3)
+    val queryMatch = client.query(Paginate(Match(testIndex, randomText1))).futureValue
 
-    val queryMatchF = client.query(Paginate(Match(testIndex, randomText1)))
-    val queryMatchR = await(queryMatchF)
+    queryMatch(PageRefs).get shouldBe Seq(create1(RefField).get)
 
-    queryMatchR(PageRefs).get shouldBe Seq(create1(RefField).get)
-
-    val queryF = client.query(Paginate(Match(randomCollectionIndex), size = 1))
-    val resp = await(queryF)
+    val resp = client.query(Paginate(Match(randomCollectionIndex), size = 1)).futureValue
 
     resp("data").to[ArrayV].get.elems.size shouldBe 1
     resp("after").isDefined should equal (true)
     resp("before").isDefined should equal (false)
 
-    val query2F = client.query(Paginate(Match(randomCollectionIndex), After(resp("after")), size = 1))
-    val resp2 = await(query2F)
+    val resp2 = client.query(Paginate(Match(randomCollectionIndex), After(resp("after")), size = 1)).futureValue
 
     resp2("data").to[Seq[Value]].get.size shouldBe 1
     resp2("after").isDefined should equal (true)
@@ -263,35 +262,34 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "paginate with cursor object" in {
     val collection =
-      await(
-        client.query(
-          CreateCollection(Obj(
-            "name" -> aRandomString
-          ))))
+      client.query(
+        CreateCollection(Obj(
+          "name" -> aRandomString
+        ))).futureValue
 
     val index =
-      await(client.query(
+      client.query(
         CreateIndex(Obj(
           "name" -> Concat(collection("name"), "_collection_index"),
           "source" -> collection("ref"),
           "active" -> true
-        ))))
+        ))).futureValue
 
-    await(client.query(
+    client.query(
       Arr(0 until 10 map { _ =>
         Create(collection("ref"), Obj(
           "name" -> aRandomString
         ))
       }: _*)
-    ))
+    ).futureValue
 
     def page(cursor: Expr): Value =
-      await(client.query(
+      client.query(
         Paginate(
           Match(index("ref")),
           cursor = cursor,
           size = 4,
-        )))
+        )).futureValue
 
     val first = page(Null())
     val second = page(Obj("after" -> first("after")))
@@ -304,211 +302,180 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "handle a constraint violation" in {
     val randomCollectionName = aRandomString
-    val randomCollectionF = client.query(CreateCollection(Obj("name" -> randomCollectionName)))
-    val collectionRef = await(randomCollectionF)(RefField).get
+    val randomCollection = client.query(CreateCollection(Obj("name" -> randomCollectionName))).futureValue
+    val collectionRef = randomCollection(RefField).get
 
-    val uniqueIndexFuture = client.query(CreateIndex(Obj(
+    client.query(CreateIndex(Obj(
       "name" -> (randomCollectionName+"_by_unique_test"),
       "source" -> collectionRef,
       "terms" -> Arr(Obj("field" -> Arr("data", "uniqueTest1"))),
-      "unique" -> true, "active" -> true)))
-
-    await(uniqueIndexFuture)
+      "unique" -> true, "active" -> true))).futureValue
 
     val randomText = aRandomString
-    val createFuture = client.query(Create(collectionRef, Obj("data" -> Obj("uniqueTest1" -> randomText))))
+    client.query(Create(collectionRef, Obj("data" -> Obj("uniqueTest1" -> randomText)))).futureValue
 
-    await(createFuture)
+    val result = client.query(Create(collectionRef, Obj("data" -> Obj("uniqueTest1" -> randomText)))).failed.futureValue
 
-    val createFuture2 = client.query(Create(collectionRef, Obj("data" -> Obj("uniqueTest1" -> randomText))))
-
-    val exception = intercept[BadRequestException] {
-      await(createFuture2)
-    }
-
-    exception.errors(0).code shouldBe "instance not unique"
+    result shouldBe a[BadRequestException]
+    result.getMessage() should include("instance not unique")
   }
 
   it should "test types" in {
-    val setF = client.query(Match(Index("spells_by_element"), "arcane"))
-    val set = await(setF).to[SetRefV].get
+    val set = client.query(Match(Index("spells_by_element"), "arcane")).futureValue.to[SetRefV].get
     set.parameters("match").to[RefV].get shouldBe RefV("spells_by_element", Native.Indexes)
     set.parameters("terms").to[String].get shouldBe "arcane"
 
-    await(client.query(Array[Byte](0x1, 0x2, 0x3, 0x4))) should equal (BytesV(0x1, 0x2, 0x3, 0x4))
+    client.query(Array[Byte](0x1, 0x2, 0x3, 0x4)).futureValue should equal (BytesV(0x1, 0x2, 0x3, 0x4))
   }
 
   it should "test basic forms" in {
-    val letF = client.query(Let { val x = 1; val y = Add(x, 2); y })
-    val letR = await(letF)
+    val letR = client.query(Let { val x = 1; val y = Add(x, 2); y }).futureValue
     letR.to[Long].get shouldBe 3
 
-    val ifF = client.query(If(true, "was true", "was false"))
-    val ifR = await(ifF)
+    val ifR = client.query(If(true, "was true", "was false")).futureValue
     ifR.to[String].get shouldBe "was true"
 
     val randomNum = Math.abs(Random.nextLong() % 250000L) + 250000L
     val randomRef = RefV(randomNum.toString, RefV("spells", Native.Collections))
-    val doF = client.query(Do(
+    val doR = client.query(Do(
       Create(randomRef, Obj("data" -> Obj("name" -> "Magic Missile"))),
       Get(randomRef)
-    ))
-    val doR = await(doF)
+    )).futureValue
     doR(RefField).get shouldBe randomRef
 
-    val objectF = client.query(Obj("name" -> "Hen Wen", "age" -> 123))
-    val objectR = await(objectF)
+    val objectR = client.query(Obj("name" -> "Hen Wen", "age" -> 123)).futureValue
     objectR("name").to[String].get shouldBe "Hen Wen"
     objectR("age").to[Long].get shouldBe 123
 
   }
 
   it should "test collections" in {
-    val mapR = await(client.query(Map(Arr(1L, 2L, 3L), Lambda(i => Add(i, 1L)))))
+    val mapR = client.query(Map(Arr(1L, 2L, 3L), Lambda(i => Add(i, 1L)))).futureValue
     mapR.to[Seq[Long]].get shouldBe Seq(2, 3, 4)
 
-    val foreachR = await(client.query(Foreach(Arr("Fireball Level 1", "Fireball Level 2"), Lambda(spell => Create(Collection("spells"), Obj("data" -> Obj("name" -> spell)))))))
+    val foreachR = client.query(Foreach(Arr("Fireball Level 1", "Fireball Level 2"), Lambda(spell => Create(Collection("spells"), Obj("data" -> Obj("name" -> spell)))))).futureValue
     foreachR.to[Seq[String]].get shouldBe Seq("Fireball Level 1", "Fireball Level 2")
 
-    val filterR = await(client.query(Filter(Arr(1, 2, 3, 4), Lambda(i => If(Equals(Modulo(i, 2), 0), true, false)))))
+    val filterR = client.query(Filter(Arr(1, 2, 3, 4), Lambda(i => If(Equals(Modulo(i, 2), 0), true, false)))).futureValue
     filterR.to[Seq[Long]].get shouldBe Seq(2, 4)
 
-    val takeR = await(client.query(Take(2, Arr(1, 2, 3, 4))))
+    val takeR = client.query(Take(2, Arr(1, 2, 3, 4))).futureValue
     takeR.to[Seq[Long]].get shouldBe Seq(1, 2)
 
-    val dropR = await(client.query(Drop(2, Arr(1, 2, 3, 4))))
+    val dropR = client.query(Drop(2, Arr(1, 2, 3, 4))).futureValue
     dropR.to[Seq[Long]].get shouldBe Seq(3, 4)
 
-    val prependR = await(client.query(Prepend(Arr(1, 2, 3), Arr(4, 5, 6))))
+    val prependR = client.query(Prepend(Arr(1, 2, 3), Arr(4, 5, 6))).futureValue
     prependR.to[Seq[Long]].get shouldBe Seq(1, 2, 3, 4, 5, 6)
 
-    val appendR = await(client.query(Append(Arr(1, 2, 3), Arr(4, 5, 6))))
+    val appendR = client.query(Append(Arr(1, 2, 3), Arr(4, 5, 6))).futureValue
     appendR.to[Seq[Long]].get shouldBe Seq(4, 5, 6, 1, 2, 3)
 
     val randomElement = aRandomString
-    await(client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "predicate test", "element" -> randomElement)))))
+    client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "predicate test", "element" -> randomElement)))).futureValue
 
     //arrays
-    await(client.query(IsEmpty(Arr(1, 2, 3)))).to[Boolean].get shouldBe false
-    await(client.query(IsEmpty(Arr()))).to[Boolean].get shouldBe true
+    client.query(IsEmpty(Arr(1, 2, 3))).futureValue.to[Boolean].get shouldBe false
+    client.query(IsEmpty(Arr())).futureValue.to[Boolean].get shouldBe true
 
-    await(client.query(IsNonEmpty(Arr(1, 2, 3)))).to[Boolean].get shouldBe true
-    await(client.query(IsNonEmpty(Arr()))).to[Boolean].get shouldBe false
+    client.query(IsNonEmpty(Arr(1, 2, 3))).futureValue.to[Boolean].get shouldBe true
+    client.query(IsNonEmpty(Arr())).futureValue.to[Boolean].get shouldBe false
 
     //pages
-    await(client.query(IsEmpty(Paginate(Match(Index("spells_by_element"), randomElement))))).to[Boolean].get shouldBe false
-    await(client.query(IsEmpty(Paginate(Match(Index("spells_by_element"), "an invalid element"))))).to[Boolean].get shouldBe true
+    client.query(IsEmpty(Paginate(Match(Index("spells_by_element"), randomElement)))).futureValue.to[Boolean].get shouldBe false
+    client.query(IsEmpty(Paginate(Match(Index("spells_by_element"), "an invalid element")))).futureValue.to[Boolean].get shouldBe true
 
-    await(client.query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), randomElement))))).to[Boolean].get shouldBe true
-    await(client.query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), "an invalid element"))))).to[Boolean].get shouldBe false
+    client.query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), randomElement)))).futureValue.to[Boolean].get shouldBe true
+    client.query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), "an invalid element")))).futureValue.to[Boolean].get shouldBe false
   }
 
   it should "test resource modification" in {
-    val createF = client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "Magic Missile", "element" -> "arcane", "cost" -> 10L))))
-    val createR = await(createF)
+    val createR = client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "Magic Missile", "element" -> "arcane", "cost" -> 10L)))).futureValue
     createR(RefField).get.collection shouldBe Some(RefV("spells", Native.Collections))
     createR(RefField).get.database shouldBe None
     createR("data", "name").to[String].get shouldBe "Magic Missile"
     createR("data", "element").to[String].get shouldBe "arcane"
     createR("data", "cost").to[Long].get shouldBe 10L
 
-    val updateF = client.query(Update(createR(RefField), Obj("data" -> Obj("name" -> "Faerie Fire", "cost" -> NullV))))
-    val updateR = await(updateF)
+    val updateR = client.query(Update(createR(RefField), Obj("data" -> Obj("name" -> "Faerie Fire", "cost" -> NullV)))).futureValue
     updateR(RefField).get shouldBe createR(RefField).get
     updateR("data", "name").to[String].get shouldBe "Faerie Fire"
     updateR("data", "element").to[String].get shouldBe "arcane"
     updateR("data", "cost").isDefined should equal (false)
 
-    val replaceF = client.query(Replace(createR("ref"), Obj("data" -> Obj("name" -> "Volcano", "element" -> Arr("fire", "earth"), "cost" -> 10L))))
-    val replaceR = await(replaceF)
+    val replaceR = client.query(Replace(createR("ref"), Obj("data" -> Obj("name" -> "Volcano", "element" -> Arr("fire", "earth"), "cost" -> 10L)))).futureValue
     replaceR("ref").get shouldBe createR("ref").get
     replaceR("data", "name").to[String].get shouldBe "Volcano"
     replaceR("data", "element").to[Seq[String]].get shouldBe Seq("fire", "earth")
     replaceR("data", "cost").to[Long].get shouldBe 10L
 
-    val insertF = client.query(Insert(createR("ref"), 1L, Action.Create, Obj("data" -> Obj("cooldown" -> 5L))))
-    val insertR = await(insertF)
+    val insertR = client.query(Insert(createR("ref"), 1L, Action.Create, Obj("data" -> Obj("cooldown" -> 5L)))).futureValue
     insertR("document").get shouldBe createR("ref").get
 
-    val removeF = client.query(Remove(createR("ref"), 2L, Action.Delete))
-    val removeR = await(removeF)
+    val removeR = client.query(Remove(createR("ref"), 2L, Action.Delete)).futureValue
     removeR shouldBe NullV
 
-    val deleteF = client.query(Delete(createR("ref")))
-    await(deleteF)
-    val getF = client.query(Get(createR("ref")))
-    intercept[NotFoundException] {
-      await(getF)
-    }
+    client.query(Delete(createR("ref"))).futureValue
+    val getR = client.query(Get(createR("ref"))).failed.futureValue
+    getR shouldBe a[NotFoundException]
   }
 
   it should "test sets" in {
-    val create1F = client.query(Create(Collection("spells"),
-      Obj("data" -> Obj("name" -> "Magic Missile", "element" -> "arcane", "cost" -> 10L))))
-    val create2F = client.query(Create(Collection("spells"),
-      Obj("data" -> Obj("name" -> "Fireball", "element" -> "fire", "cost" -> 10L))))
-    val create3F = client.query(Create(Collection("spells"),
-      Obj("data" -> Obj("name" -> "Faerie Fire", "element" -> Arr("arcane", "nature"), "cost" -> 10L))))
-    val create4F = client.query(Create(Collection("spells"),
-      Obj("data" -> Obj("name" -> "Summon Animal Companion", "element" -> "nature", "cost" -> 10L))))
+    val create1R = client.query(Create(Collection("spells"),
+      Obj("data" -> Obj("name" -> "Magic Missile", "element" -> "arcane", "cost" -> 10L)))).futureValue
+    val create2R = client.query(Create(Collection("spells"),
+      Obj("data" -> Obj("name" -> "Fireball", "element" -> "fire", "cost" -> 10L)))).futureValue
+    val create3R = client.query(Create(Collection("spells"),
+      Obj("data" -> Obj("name" -> "Faerie Fire", "element" -> Arr("arcane", "nature"), "cost" -> 10L)))).futureValue
+    val create4R = client.query(Create(Collection("spells"),
+      Obj("data" -> Obj("name" -> "Summon Animal Companion", "element" -> "nature", "cost" -> 10L)))).futureValue
 
-    val create1R = await(create1F)
-    val create2R = await(create2F)
-    val create3R = await(create3F)
-    val create4R = await(create4F)
-
-    val matchF = client.query(Paginate(Match(Index("spells_by_element"), "arcane")))
-    val matchR = await(matchF)
+    val matchR = client.query(Paginate(Match(Index("spells_by_element"), "arcane"))).futureValue
     matchR("data").to[Seq[RefV]].get should contain (create1R("ref").get)
 
-    val matchEventsF = client.query(Paginate(Match(Index("spells_by_element"), "arcane"), events = true))
-    val matchEventsR = await(matchEventsF)
+    val matchEventsR = client.query(Paginate(Match(Index("spells_by_element"), "arcane"), events = true)).futureValue
     matchEventsR(PageEvents).get map { _.ref } should contain (create1R("ref").to[RefV].get)
 
-    val unionF = client.query(Paginate(Union(
+    val unionR = client.query(Paginate(Union(
       Match(Index("spells_by_element"), "arcane"),
-      Match(Index("spells_by_element"), "fire"))))
-    val unionR = await(unionF)
+      Match(Index("spells_by_element"), "fire")))).futureValue
     unionR(PageRefs).get should (contain (create1R(RefField).get) and contain (create2R(RefField).get))
 
-    val unionEventsF = client.query(Paginate(Union(
+    val unionEventsR = client.query(Paginate(Union(
       Match(Index("spells_by_element"), "arcane"),
-      Match(Index("spells_by_element"), "fire")), events = true))
-    val unionEventsR = await(unionEventsF)
+      Match(Index("spells_by_element"), "fire")), events = true)).futureValue
 
     unionEventsR(PageEvents).get collect { case e if e.action == "add" => e.ref } should (
       contain (create1R(RefField).get) and contain (create2R(RefField).get))
 
-    val intersectionF = client.query(Paginate(Intersection(
+    val intersectionR = client.query(Paginate(Intersection(
       Match(Index("spells_by_element"), "arcane"),
-      Match(Index("spells_by_element"), "nature"))))
-    val intersectionR = await(intersectionF)
+      Match(Index("spells_by_element"), "nature")))).futureValue
     intersectionR(PageRefs).get should contain (create3R(RefField).get)
 
-    val differenceF = client.query(Paginate(Difference(
+    val differenceR = client.query(Paginate(Difference(
       Match(Index("spells_by_element"), "nature"),
-      Match(Index("spells_by_element"), "arcane"))))
+      Match(Index("spells_by_element"), "arcane")))).futureValue
 
-    val differenceR = await(differenceF)
     differenceR(PageRefs).get should contain (create4R(RefField).get)
   }
 
   it should "test events api" in {
     val randomCollectionName = aRandomString
-    val randomCollection = await(client.query(CreateCollection(Obj("name" -> randomCollectionName))))
+    val randomCollection = client.query(CreateCollection(Obj("name" -> randomCollectionName))).futureValue
 
-    val data = await(client.query(Create(randomCollection(RefField).get, Obj("data" -> Obj("x" -> 1)))))
+    val data = client.query(Create(randomCollection(RefField).get, Obj("data" -> Obj("x" -> 1)))).futureValue
     val dataRef = data(RefField).get
 
-    await(client.query(Update(dataRef, Obj("data" -> Obj("x" -> 2)))))
-    await(client.query(Delete(dataRef)))
+    client.query(Update(dataRef, Obj("data" -> Obj("x" -> 2)))).futureValue
+    client.query(Delete(dataRef)).futureValue
 
     case class Event(action: String, document: RefV)
 
     implicit val eventCodec = Codec.Record[Event]
 
     // Events
-    val events = await(client.query(Paginate(Events(dataRef))))(DataField.to[List[Event]]).get
+    val events = (client.query(Paginate(Events(dataRef))).futureValue).apply(DataField.to[List[Event]]).get
 
     events.length shouldBe 3
     events(0).action shouldBe "create"
@@ -521,7 +488,8 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     events(2).document shouldBe dataRef
 
     // Singleton
-    val singletons = await(client.query(Paginate(Events(Singleton(dataRef)))))(DataField.to[List[Event]]).get
+    val singletonsR = client.query(Paginate(Events(Singleton(dataRef)))).futureValue
+    val singletons = singletonsR(DataField.to[List[Event]]).get
 
     singletons.length shouldBe 2
     singletons(0).action shouldBe "add"
@@ -532,343 +500,281 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "test string functions" in {
-    await(client.query(ContainsStr("ABCDEF","CDE"))).to[Boolean].get shouldBe true
-    await(client.query(ContainsStr("ABCDEF","GHI"))).to[Boolean].get shouldBe false
+    (client.query(ContainsStr("ABCDEF","CDE")).futureValue).to[Boolean].get shouldBe true
+    (client.query(ContainsStr("ABCDEF","GHI")).futureValue).to[Boolean].get shouldBe false
 
-    await(client.query(ContainsStrRegex("ABCDEF","[A-Z]"))).to[Boolean].get shouldBe true
-    await(client.query(ContainsStrRegex("123456","[A-Z]"))).to[Boolean].get shouldBe false
+    (client.query(ContainsStrRegex("ABCDEF","[A-Z]")).futureValue).to[Boolean].get shouldBe true
+    (client.query(ContainsStrRegex("123456","[A-Z]")).futureValue).to[Boolean].get shouldBe false
 
-    await(client.query(EndsWith("ABCDEF","DEF"))).to[Boolean].get shouldBe true
-    await(client.query(EndsWith("ABCDEF","ABC"))).to[Boolean].get shouldBe false
+    (client.query(EndsWith("ABCDEF","DEF")).futureValue).to[Boolean].get shouldBe true
+    (client.query(EndsWith("ABCDEF","ABC")).futureValue).to[Boolean].get shouldBe false
 
-    await(client.query(FindStr("heLLo world","world"))).to[Long].get shouldBe 6L
-    await(client.query(Length("heLLo world"))).to[Long].get shouldBe 11L
-    await(client.query(LowerCase("hEllO wORLd"))).to[String].get shouldBe "hello world"
-    await(client.query(LTrim("   hello world"))).to[String].get shouldBe "hello world"
-    await(client.query(RegexEscape("ABCDEF"))).to[String].get shouldBe """\QABCDEF\E"""
-    await(client.query(ReplaceStrRegex("hello world","hello","bye"))).to[String].get shouldBe "bye world"
-    await(client.query(Repeat("bye "))).to[String].get shouldBe "bye bye "
-    await(client.query(Repeat("bye ",3))).to[String].get shouldBe "bye bye bye "
-    await(client.query(ReplaceStr("hello world","hello","bye"))).to[String].get shouldBe "bye world"
-    await(client.query(RTrim("hello world    "))).to[String].get shouldBe "hello world"
-    await(client.query(Space(4))).to[String].get shouldBe "    "
+    (client.query(FindStr("heLLo world","world")).futureValue).to[Long].get shouldBe 6L
+    (client.query(Length("heLLo world")).futureValue).to[Long].get shouldBe 11L
+    (client.query(LowerCase("hEllO wORLd")).futureValue).to[String].get shouldBe "hello world"
+    (client.query(LTrim("   hello world")).futureValue).to[String].get shouldBe "hello world"
+    (client.query(RegexEscape("ABCDEF")).futureValue).to[String].get shouldBe """\QABCDEF\E"""
+    (client.query(ReplaceStrRegex("hello world","hello","bye")).futureValue).to[String].get shouldBe "bye world"
+    (client.query(Repeat("bye ")).futureValue).to[String].get shouldBe "bye bye "
+    (client.query(Repeat("bye ",3)).futureValue).to[String].get shouldBe "bye bye bye "
+    (client.query(ReplaceStr("hello world","hello","bye")).futureValue).to[String].get shouldBe "bye world"
+    (client.query(RTrim("hello world    ")).futureValue).to[String].get shouldBe "hello world"
+    (client.query(Space(4)).futureValue).to[String].get shouldBe "    "
 
-    await(client.query(StartsWith("ABCDEF","ABC"))).to[Boolean].get shouldBe true
-    await(client.query(StartsWith("ABCDEF","DEF"))).to[Boolean].get shouldBe false
+    (client.query(StartsWith("ABCDEF","ABC")).futureValue).to[Boolean].get shouldBe true
+    (client.query(StartsWith("ABCDEF","DEF")).futureValue).to[Boolean].get shouldBe false
 
-    await(client.query(SubString("heLLo world", 6))).to[String].get shouldBe "world"
-    await(client.query(Trim("    hello world    "))).to[String].get shouldBe "hello world"
-    await(client.query(TitleCase("heLLo worlD"))).to[String].get shouldBe "Hello World"
-    await(client.query(UpperCase("hello world"))).to[String].get shouldBe "HELLO WORLD"
+    (client.query(SubString("heLLo world", 6)).futureValue).to[String].get shouldBe "world"
+    (client.query(Trim("    hello world    ")).futureValue).to[String].get shouldBe "hello world"
+    (client.query(TitleCase("heLLo worlD")).futureValue).to[String].get shouldBe "Hello World"
+    (client.query(UpperCase("hello world")).futureValue).to[String].get shouldBe "HELLO WORLD"
 
-    await(client.query(Casefold("Hen Wen"))).to[String].get shouldBe "hen wen"
+    (client.query(Casefold("Hen Wen")).futureValue).to[String].get shouldBe "hen wen"
 
     // https://unicode.org/reports/tr15/
-    await(client.query(Casefold("\u212B", Normalizer.NFD))).to[String].get shouldBe "A\u030A"
-    await(client.query(Casefold("\u212B", Normalizer.NFC))).to[String].get shouldBe "\u00C5"
-    await(client.query(Casefold("\u1E9B\u0323", Normalizer.NFKD))).to[String].get shouldBe "\u0073\u0323\u0307"
-    await(client.query(Casefold("\u1E9B\u0323", Normalizer.NFKC))).to[String].get shouldBe "\u1E69"
-    await(client.query(Casefold("\u212B", Normalizer.NFKCCaseFold))).to[String].get shouldBe "\u00E5"
+    (client.query(Casefold("\u212B", Normalizer.NFD)).futureValue).to[String].get shouldBe "A\u030A"
+    (client.query(Casefold("\u212B", Normalizer.NFC)).futureValue).to[String].get shouldBe "\u00C5"
+    (client.query(Casefold("\u1E9B\u0323", Normalizer.NFKD)).futureValue).to[String].get shouldBe "\u0073\u0323\u0307"
+    (client.query(Casefold("\u1E9B\u0323", Normalizer.NFKC)).futureValue).to[String].get shouldBe "\u1E69"
+    (client.query(Casefold("\u212B", Normalizer.NFKCCaseFold)).futureValue).to[String].get shouldBe "\u00E5"
 
-    await(client.query(NGram("what"))).to[Seq[String]].get shouldBe Seq("w", "wh", "h", "ha", "a", "at", "t")
-    await(client.query(NGram("what", 2, 3))).to[Seq[String]].get shouldBe Seq("wh", "wha", "ha", "hat", "at")
+    (client.query(NGram("what")).futureValue).to[Seq[String]].get shouldBe Seq("w", "wh", "h", "ha", "a", "at", "t")
+    (client.query(NGram("what", 2, 3)).futureValue).to[Seq[String]].get shouldBe Seq("wh", "wha", "ha", "hat", "at")
 
-    await(client.query(NGram(Arr("john", "doe")))).to[Seq[String]].get shouldBe Seq("j", "jo", "o", "oh", "h", "hn", "n", "d", "do", "o", "oe", "e")
-    await(client.query(NGram(Arr("john", "doe"), 3, 4))).to[Seq[String]].get shouldBe Seq("joh", "john", "ohn", "doe")
+    (client.query(NGram(Arr("john", "doe"))).futureValue).to[Seq[String]].get shouldBe Seq("j", "jo", "o", "oh", "h", "hn", "n", "d", "do", "o", "oe", "e")
+    (client.query(NGram(Arr("john", "doe"), 3, 4)).futureValue).to[Seq[String]].get shouldBe Seq("joh", "john", "ohn", "doe")
 
-    await(client.query(Format("%3$s%1$s %2$s", "DB", "rocks", "Fauna"))).to[String].get shouldBe "FaunaDB rocks"
+    (client.query(Format("%3$s%1$s %2$s", "DB", "rocks", "Fauna")).futureValue).to[String].get shouldBe "FaunaDB rocks"
   }
 
   it should "test math functions" in {
 
-    val absF = client.query(Abs(-100L))
-    val absR = await(absF).to[Long].get
-    absR shouldBe 100L
+    val absR = client.query(Abs(-100L)).futureValue
+    absR.to[Long].get shouldBe 100L
 
-    val acosF = client.query(Trunc(Acos(0.5D), 2))
-    val acosR = await(acosF).to[Double].get
-    acosR shouldBe 1.04D
+    val acosR = client.query(Trunc(Acos(0.5D), 2)).futureValue
+    acosR.to[Double].get shouldBe 1.04D
 
-    val addF = client.query(Add(100L, 10L))
-    val addR = await(addF).to[Long].get
-    addR shouldBe 110L
+    val addR = client.query(Add(100L, 10L)).futureValue
+    addR.to[Long].get shouldBe 110L
 
-    val asinF = client.query(Trunc(Asin(0.5D), 2))
-    val asinR = await(asinF).to[Double].get
-    asinR shouldBe 0.52D
+    val asinR = client.query(Trunc(Asin(0.5D), 2)).futureValue
+    asinR.to[Double].get shouldBe 0.52D
 
-    val atanF = client.query(Trunc(Atan(0.5D), 2))
-    val atanR = await(atanF).to[Double].get
-    atanR shouldBe 0.46D
+    val atanR = client.query(Trunc(Atan(0.5D), 2)).futureValue
+    atanR.to[Double].get shouldBe 0.46D
 
-    val bitandF = client.query(BitAnd(15L, 7L, 3L))
-    val bitandR = await(bitandF).to[Long].get
-    bitandR shouldBe 3L
+    val bitandR = client.query(BitAnd(15L, 7L, 3L)).futureValue
+    bitandR.to[Long].get shouldBe 3L
 
-    val bitnotF = client.query(BitNot(3L))
-    val bitnotR = await(bitnotF).to[Long].get
-    bitnotR shouldBe -4L
+    val bitnotR = client.query(BitNot(3L)).futureValue
+    bitnotR.to[Long].get shouldBe -4L
 
-    val bitorF = client.query(BitOr(15L, 7L, 3L))
-    val bitorR = await(bitorF).to[Long].get
-    bitorR shouldBe 15L
+    val bitorR = client.query(BitOr(15L, 7L, 3L)).futureValue
+    bitorR.to[Long].get shouldBe 15L
 
-    val bitxorF = client.query(BitXor(2L, 1L))
-    val bitxorR = await(bitxorF).to[Long].get
-    bitxorR shouldBe 3L
+    val bitxorR = client.query(BitXor(2L, 1L)).futureValue
+    bitxorR.to[Long].get shouldBe 3L
 
-    val ceilF = client.query(Ceil(1.01D))
-    val ceilR = await(ceilF).to[Double].get
-    ceilR shouldBe 2.0D
+    val ceilR = client.query(Ceil(1.01D)).futureValue
+    ceilR.to[Double].get shouldBe 2.0D
 
-    val cosF = client.query(Trunc(Cos(0.5D), 2))
-    val cosR = await(cosF).to[Double].get
-    cosR shouldBe 0.87D
+    val cosR = client.query(Trunc(Cos(0.5D), 2)).futureValue
+    cosR.to[Double].get shouldBe 0.87D
 
-    val coshF = client.query(Trunc(Cosh(2L),2))
-    val coshR = await(coshF).to[Double].get
-    coshR shouldBe 3.76D
+    val coshR = client.query(Trunc(Cosh(2L),2)).futureValue
+    coshR.to[Double].get shouldBe 3.76D
 
-    val degreesF = client.query(Trunc(Degrees(2.0D),2))
-    val degreesR = await(degreesF).to[Double].get
-    degreesR shouldBe 114.59D
+    val degreesR = client.query(Trunc(Degrees(2.0D),2)).futureValue
+    degreesR.to[Double].get shouldBe 114.59D
 
-    val divideF = client.query(Divide(100L, 10L))
-    val divideR = await(divideF).to[Long].get
-    divideR shouldBe 10L
+    val divideR = client.query(Divide(100L, 10L)).futureValue
+    divideR.to[Long].get shouldBe 10L
 
-    val expF = client.query(Trunc(Exp(2L), 2))
-    val expR = await(expF).to[Double].get
-    expR shouldBe 7.38D
+    val expR = client.query(Trunc(Exp(2L), 2)).futureValue
+    expR.to[Double].get shouldBe 7.38D
 
-    val floorF = client.query(Floor(1.91D))
-    val floorR = await(floorF).to[Double].get
-    floorR shouldBe 1.0D
+    val floorR = client.query(Floor(1.91D)).futureValue
+    floorR.to[Double].get shouldBe 1.0D
 
-    val hypotF = client.query(Hypot(3D, 4D))
-    val  hypotR = await(hypotF).to[Double].get
-    hypotR shouldBe 5.0D
+    val hypotR = client.query(Hypot(3D, 4D)).futureValue
+    hypotR.to[Double].get shouldBe 5.0D
 
-    val lnF = client.query(Trunc(Ln(2L),2))
-    val lnR = await(lnF).to[Double].get
-    lnR shouldBe 0.69D
+    val lnR = client.query(Trunc(Ln(2L),2)).futureValue
+    lnR.to[Double].get shouldBe 0.69D
 
-    val logF = client.query(Trunc(Log(2L),2))
-    val logR = await(logF).to[Double].get
-    logR shouldBe 0.30D
+    val logR = client.query(Trunc(Log(2L),2)).futureValue
+    logR.to[Double].get shouldBe 0.30D
 
-    val maxF = client.query(Max(101L, 10L, 1L))
-    val maxR = await(maxF).to[Long].get
-    maxR shouldBe 101L
+    val maxR = client.query(Max(101L, 10L, 1L)).futureValue
+    maxR.to[Long].get shouldBe 101L
 
-    val minF = client.query(Min(101L, 10L))
-    val minR = await(minF).to[Long].get
-    minR shouldBe 10L
+    val minR = client.query(Min(101L, 10L)).futureValue
+    minR.to[Long].get shouldBe 10L
 
-    val moduloF = client.query(Modulo(101L, 10L))
-    val moduloR = await(moduloF).to[Long].get
-    moduloR shouldBe 1L
+    val moduloR = client.query(Modulo(101L, 10L)).futureValue
+    moduloR.to[Long].get shouldBe 1L
 
-    val multiplyF = client.query(Multiply(100L, 10L))
-    val multiplyR = await(multiplyF).to[Long].get
-    multiplyR shouldBe 1000L
+    val multiplyR = client.query(Multiply(100L, 10L)).futureValue
+    multiplyR.to[Long].get shouldBe 1000L
 
-    val radiansF = client.query(Trunc(Radians(500), 2))
-    val radiansR = await(radiansF).to[Double].get
-    radiansR shouldBe 8.72D
+    val radiansR = client.query(Trunc(Radians(500), 2)).futureValue
+    radiansR.to[Double].get shouldBe 8.72D
 
-    val roundF = client.query(Round(12345.6789))
-    val roundR = await(roundF).to[Double].get
-    roundR shouldBe 12345.68D
+    val roundR = client.query(Round(12345.6789)).futureValue
+    roundR.to[Double].get shouldBe 12345.68D
 
-    val signF = client.query(Sign(3L))
-    val signR = await(signF).to[Long].get
-    signR shouldBe 1L
+    val signR = client.query(Sign(3L)).futureValue
+    signR.to[Long].get shouldBe 1L
 
-    val sinF = client.query(Trunc(Sin(0.5D), 2))
-    val sinR = await(sinF).to[Double].get
-    sinR shouldBe 0.47D
+    val sinR = client.query(Trunc(Sin(0.5D), 2)).futureValue
+    sinR.to[Double].get shouldBe 0.47D
 
-    val sinhF = client.query(Trunc(Sinh(0.5D), 2))
-    val sinhR = await(sinhF).to[Double].get
-    sinhR shouldBe 0.52D
+    val sinhR = client.query(Trunc(Sinh(0.5D), 2)).futureValue
+    sinhR.to[Double].get shouldBe 0.52D
 
-    val sqrtF = client.query(Sqrt(16L))
-    val sqrtR = await(sqrtF).to[Double].get
-    sqrtR shouldBe 4L
+    val sqrtR = client.query(Sqrt(16L)).futureValue
+    sqrtR.to[Double].get shouldBe 4L
 
-    val subtractF = client.query(Subtract(100L, 10L))
-    val subtractR = await(subtractF).to[Long].get
-    subtractR shouldBe 90L
+    val subtractR = client.query(Subtract(100L, 10L)).futureValue
+    subtractR.to[Long].get shouldBe 90L
 
-    val tanF = client.query(Trunc(Tan(0.5D), 2))
-    val tanR = await(tanF).to[Double].get
-    tanR shouldBe 0.54D
+    val tanR = client.query(Trunc(Tan(0.5D), 2)).futureValue
+    tanR.to[Double].get shouldBe 0.54D
 
-    val tanhF = client.query(Trunc(Tanh(0.5D), 2))
-    val tanhR = await(tanhF).to[Double].get
-    tanhR shouldBe 0.46D
+    val tanhR = client.query(Trunc(Tanh(0.5D), 2)).futureValue
+    tanhR.to[Double].get shouldBe 0.46D
 
-    val truncF = client.query(Trunc(123.456D, 2L))
-    val truncR = await(truncF).to[Double].get
-    truncR shouldBe 123.45D
+    val truncR = client.query(Trunc(123.456D, 2L)).futureValue
+    truncR.to[Double].get shouldBe 123.45D
 
   }
 
   it should "test miscellaneous functions" in {
-    val newIdF = client.query(NewId())
-    val newIdR = await(newIdF).to[String].get
-    newIdR should not be null
+    val newIdR = client.query(NewId()).futureValue
+    newIdR.to[String].get should not be null
 
-    val equalsF = client.query(Equals("fire", "fire"))
-    val equalsR = await(equalsF).to[Boolean].get
-    equalsR shouldBe true
+    val equalsR = client.query(Equals("fire", "fire")).futureValue
+    equalsR.to[Boolean].get shouldBe true
 
-    val concatF = client.query(Concat(Arr("Magic", "Missile")))
-    val concatR = await(concatF).to[String].get
-    concatR shouldBe "MagicMissile"
+    val concatR = client.query(Concat(Arr("Magic", "Missile"))).futureValue
+    concatR.to[String].get shouldBe "MagicMissile"
 
-    val concat2F = client.query(Concat(Arr("Magic", "Missile"), " "))
-    val concat2R = await(concat2F).to[String].get
-    concat2R shouldBe "Magic Missile"
+    val concat2R = client.query(Concat(Arr("Magic", "Missile"), " ")).futureValue
+    concat2R.to[String].get shouldBe "Magic Missile"
 
-    val containsF = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings")))))
-    val containsR = await(containsF).to[Boolean].get
-    containsR shouldBe true
+    val containsR = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings"))))).futureValue
+    containsR.to[Boolean].get shouldBe true
 
-    await(client.query(Contains("field", Obj("field" -> "value")))) shouldBe TrueV
-    await(client.query(Contains(1, Arr("value0", "value1", "value2")))) shouldBe TrueV
+    client.query(Contains("field", Obj("field" -> "value"))).futureValue shouldBe TrueV
+    client.query(Contains(1, Arr("value0", "value1", "value2"))).futureValue shouldBe TrueV
 
-    val selectF = client.query(Select("favorites" / "foods" / 1, Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings", "lunchings")))))
-    val selectR = await(selectF).to[String].get
-    selectR shouldBe "munchings"
+    val selectR = client.query(Select("favorites" / "foods" / 1, Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings", "lunchings"))))).futureValue
+    selectR.to[String].get shouldBe "munchings"
 
-    await(client.query(Select("field", Obj("field" -> "value")))) shouldBe StringV("value")
-    await(client.query(Select("non-existent-field", Obj("field" -> "value"), "a default value"))) shouldBe StringV("a default value")
+    client.query(Select("field", Obj("field" -> "value"))).futureValue shouldBe StringV("value")
+    client.query(Select("non-existent-field", Obj("field" -> "value"), "a default value")).futureValue shouldBe StringV("a default value")
 
-    await(client.query(Select(1, Arr("value0", "value1", "value2")))) shouldBe StringV("value1")
-    await(client.query(Select(100, Arr("value0", "value1", "value2"), "a default value"))) shouldBe StringV("a default value")
+    client.query(Select(1, Arr("value0", "value1", "value2"))).futureValue shouldBe StringV("value1")
+    client.query(Select(100, Arr("value0", "value1", "value2"), "a default value")).futureValue shouldBe StringV("a default value")
 
-    await(client.query(Contains("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value"))))))) shouldBe TrueV
-    await(client.query(Select("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value"))))))) shouldBe StringV("value")
+    client.query(Contains("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value")))))).futureValue shouldBe TrueV
+    client.query(Select("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value")))))).futureValue shouldBe StringV("value")
 
-    await(client.query(SelectAll("foo", Arr(Obj("foo" -> "bar"), Obj("foo" -> "baz"), Obj("a" -> "b"))))) shouldBe ArrayV("bar", "baz")
-    await(client.query(SelectAll("foo" / "bar", Arr(Obj("foo" -> Obj("bar" -> 1)), Obj("foo" -> Obj("bar" -> 2)))))) shouldBe ArrayV(1, 2)
-    await(client.query(SelectAll("foo" / 0, Arr(Obj("foo" -> Arr(0, 1)), Obj("foo" -> Arr(2, 3)))))) shouldBe ArrayV(0, 2)
+    client.query(SelectAll("foo", Arr(Obj("foo" -> "bar"), Obj("foo" -> "baz"), Obj("a" -> "b")))).futureValue shouldBe ArrayV("bar", "baz")
+    client.query(SelectAll("foo" / "bar", Arr(Obj("foo" -> Obj("bar" -> 1)), Obj("foo" -> Obj("bar" -> 2))))).futureValue shouldBe ArrayV(1, 2)
+    client.query(SelectAll("foo" / 0, Arr(Obj("foo" -> Arr(0, 1)), Obj("foo" -> Arr(2, 3))))).futureValue shouldBe ArrayV(0, 2)
 
-    await(client.query(SelectAsIndex("foo", Arr(Obj("foo" -> "bar"), Obj("foo" -> "baz"), Obj("a" -> "b"))))) shouldBe ArrayV("bar", "baz")
-    await(client.query(SelectAsIndex("foo" / "bar", Arr(Obj("foo" -> Obj("bar" -> 1)), Obj("foo" -> Obj("bar" -> 2)))))) shouldBe ArrayV(1, 2)
-    await(client.query(SelectAsIndex("foo" / 0, Arr(Obj("foo" -> Arr(0, 1)), Obj("foo" -> Arr(2, 3)))))) shouldBe ArrayV(0, 2)
+    client.query(SelectAsIndex("foo", Arr(Obj("foo" -> "bar"), Obj("foo" -> "baz"), Obj("a" -> "b")))).futureValue shouldBe ArrayV("bar", "baz")
+    client.query(SelectAsIndex("foo" / "bar", Arr(Obj("foo" -> Obj("bar" -> 1)), Obj("foo" -> Obj("bar" -> 2))))).futureValue shouldBe ArrayV(1, 2)
+    client.query(SelectAsIndex("foo" / 0, Arr(Obj("foo" -> Arr(0, 1)), Obj("foo" -> Arr(2, 3))))).futureValue shouldBe ArrayV(0, 2)
 
-    val andF = client.query(And(true, false))
-    val andR = await(andF).to[Boolean].get
-    andR shouldBe false
+    val andR = client.query(And(true, false)).futureValue
+    andR.to[Boolean].get shouldBe false
 
-    val orF = client.query(Or(true, false))
-    val orR = await(orF).to[Boolean].get
-    orR shouldBe true
+    val orR = client.query(Or(true, false)).futureValue
+    orR.to[Boolean].get shouldBe true
 
-    val notF = client.query(Not(false))
-    val notR = await(notF).to[Boolean].get
-    notR shouldBe true
+    val notR = client.query(Not(false)).futureValue
+    notR.to[Boolean].get shouldBe true
   }
 
   it should "test conversion functions" in {
-    val strF = client.query(ToString(100L))
-    val strR = await(strF).to[String].get
-    strR should equal ("100")
+    val strR = client.query(ToString(100L)).futureValue
+    strR.to[String].get should equal ("100")
 
-    val numF = client.query(ToNumber("100"))
-    val numR = await(numF).to[Long].get
-    numR should equal (100L)
+    val numR = client.query(ToNumber("100")).futureValue
+    numR.to[Long].get should equal (100L)
 
-    await(client.query(
+    (client.query(
       Arr(ToDouble(3.14d), ToDouble(10L), ToDouble("3.14"))
-    )).to[List[Double]].get shouldBe List(3.14D, 10D, 3.14D)
+    ).futureValue).to[List[Double]].get shouldBe List(3.14D, 10D, 3.14D)
 
-    val doubleErr = the[BadRequestException] thrownBy {
-      await(client.query(ToDouble(Now())))
-    }
+    val doubleErr = client.query(ToDouble(Now())).failed.futureValue
+    doubleErr shouldBe a[BadRequestException]
+    doubleErr.getMessage should include ("invalid argument: Cannot cast Time to Double.")
 
-    doubleErr.getMessage shouldBe "invalid argument: Cannot cast Time to Double."
-
-    await(client.query(
+    (client.query(
       Arr(ToInteger(10D), ToInteger(10L), ToInteger("10"))
-    )).to[List[Long]].get shouldBe List(10L, 10L, 10L)
+    ).futureValue).to[List[Long]].get shouldBe List(10L, 10L, 10L)
 
-    val integerErr = the[BadRequestException] thrownBy {
-      await(client.query(ToInteger(Now())))
-    }
-
-    integerErr.getMessage shouldBe "invalid argument: Cannot cast Time to Integer."
+    val integerErr = client.query(ToInteger(Now())).failed.futureValue
+    integerErr shouldBe a[BadRequestException]
+    integerErr.getMessage should include ("invalid argument: Cannot cast Time to Integer.")
   }
 
   it should "test time functions" in {
     import java.util.Calendar._
 
-    val timeF = client.query(ToTime("1970-01-01T00:00:00Z"))
-    val timeR = await(timeF).to[TimeV].get.toInstant
-    timeR should equal (Instant.ofEpochMilli(0))
+    val timeR = client.query(ToTime("1970-01-01T00:00:00Z")).futureValue
+    timeR.to[TimeV].get.toInstant should equal (Instant.ofEpochMilli(0))
 
-    val dateF = client.query(ToDate("1970-01-01"))
-    val dateR = await(dateF).to[DateV].get.localDate
-    dateR should equal (LocalDate.ofEpochDay(0))
+    val dateR = client.query(ToDate("1970-01-01")).futureValue
+    dateR.to[DateV].get.localDate should equal (LocalDate.ofEpochDay(0))
 
     val cal = java.util.Calendar.getInstance()
     val nowStr = Time(cal.toInstant.toString)
 
-    val toSecondsF = client.query(ToSeconds(Epoch(0, TimeUnit.Second)))
-    val secondsR = await(toSecondsF).to[Long].get
-    secondsR should equal (0)
+    val secondsR = client.query(ToSeconds(Epoch(0, TimeUnit.Second))).futureValue
+    secondsR.to[Long].get should equal (0)
 
-    val toMillisF = client.query(ToMillis(nowStr))
-    val toMillisR = await(toMillisF).to[Long].get
-    toMillisR should equal (cal.getTimeInMillis)
+    val toMillisR = client.query(ToMillis(nowStr)).futureValue
+    toMillisR.to[Long].get should equal (cal.getTimeInMillis)
 
-    val toMicrosF = client.query(ToMicros(Epoch(1552733214259L, TimeUnit.Second)))
-    val toMicrosR = await(toMicrosF).to[Long].get
-    toMicrosR should equal (1552733214259000000L)
+    val toMicrosR = client.query(ToMicros(Epoch(1552733214259L, TimeUnit.Second))).futureValue
+    toMicrosR.to[Long].get should equal (1552733214259000000L)
 
-    val dayOfYearF = client.query(DayOfYear(nowStr))
-    val dayOfYearR = await(dayOfYearF).to[Long].get
-    dayOfYearR should equal (cal.get(DAY_OF_YEAR))
+    val dayOfYearR = client.query(DayOfYear(nowStr)).futureValue
+    dayOfYearR.to[Long].get should equal (cal.get(DAY_OF_YEAR))
 
-    val dayOfMonthF = client.query(DayOfMonth(nowStr))
-    val dayOfMonthR = await(dayOfMonthF).to[Long].get
-    dayOfMonthR should equal (cal.get(DAY_OF_MONTH))
+    val dayOfMonthR = client.query(DayOfMonth(nowStr)).futureValue
+    dayOfMonthR.to[Long].get should equal (cal.get(DAY_OF_MONTH))
 
-    val dayOfWeekF = client.query(DayOfWeek(nowStr))
-    val dayOfWeekR = await(dayOfWeekF).to[Long].get
-    dayOfWeekR should equal (cal.get(DAY_OF_WEEK)-1)
+    val dayOfWeekR = client.query(DayOfWeek(nowStr)).futureValue
+    dayOfWeekR.to[Long].get should equal (cal.get(DAY_OF_WEEK)-1)
 
-    val yearF = client.query(Year(nowStr))
-    val yearR = await(yearF).to[Long].get
-    yearR should equal (cal.get(YEAR))
+    val yearR = client.query(Year(nowStr)).futureValue
+    yearR.to[Long].get should equal (cal.get(YEAR))
 
-    val monthF = client.query(Month(nowStr))
-    val monthR = await(monthF).to[Long].get
-    monthR should equal (cal.get(MONTH)+1)
+    val monthR = client.query(Month(nowStr)).futureValue
+    monthR.to[Long].get should equal (cal.get(MONTH)+1)
 
-    val hourF = client.query(Hour(Epoch(0, TimeUnit.Second)))
-    val hourR = await(hourF).to[Long].get
-    hourR should equal (0)
+    val hourR = client.query(Hour(Epoch(0, TimeUnit.Second))).futureValue
+    hourR.to[Long].get should equal (0)
 
-    val minuteF = client.query(Minute(nowStr))
-    val minuteR = await(minuteF).to[Long].get
-    minuteR should equal (cal.get(MINUTE))
+    val minuteR = client.query(Minute(nowStr)).futureValue
+    minuteR.to[Long].get should equal (cal.get(MINUTE))
 
-    val secondF = client.query(query.Second(nowStr))
-    val secondR = await(secondF).to[Long].get
-    secondR should equal (cal.get(SECOND))
+    val secondR = client.query(query.Second(nowStr)).futureValue
+    secondR.to[Long].get should equal (cal.get(SECOND))
   }
 
   it should "test date and time functions" in {
-    val timeF = client.query(Time("1970-01-01T00:00:00-04:00"))
-    val timeR = await(timeF)
+    val timeR = client.query(Time("1970-01-01T00:00:00-04:00")).futureValue
     timeR.to[TimeV].get.toInstant shouldBe Instant.ofEpochMilli(0).plus(4, ChronoUnit.HOURS)
     timeR.to[Instant].get shouldBe Instant.ofEpochMilli(0).plus(4, ChronoUnit.HOURS)
 
-    val epochR = await(client.query(Arr(
+    val epochR = client.query(Arr(
       Epoch(2, TimeUnit.Day),
       Epoch(1, TimeUnit.HalfDay),
       Epoch(12, TimeUnit.Hour),
@@ -877,7 +783,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
       Epoch(10, TimeUnit.Millisecond),
       Epoch(42, TimeUnit.Nanosecond),
       Epoch(40, TimeUnit.Microsecond)
-    )))
+    )).futureValue
 
     epochR.collect(Field.to[Instant]).get.sorted shouldBe Seq(
       Instant.ofEpochMilli(0).plus(42, ChronoUnit.NANOS),
@@ -893,69 +799,60 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     epochR(0).to[TimeV].get.toInstant shouldBe Instant.ofEpochMilli(0).plus(2, ChronoUnit.DAYS)
     epochR(0).to[Instant].get shouldBe Instant.ofEpochMilli(0).plus(2, ChronoUnit.DAYS)
 
-    val dateF = client.query(query.Date("1970-01-02"))
-    val dateR = await(dateF)
+    val dateR = client.query(query.Date("1970-01-02")).futureValue
     dateR.to[DateV].get.localDate shouldBe LocalDate.ofEpochDay(1)
     dateR.to[LocalDate].get shouldBe LocalDate.ofEpochDay(1)
   }
 
   it should "test date and time match functions" in {
-    val addTimeF = client.query(TimeAdd(Epoch(0, TimeUnit.Second), 1, TimeUnit.Day))
-    val addTimeR = await(addTimeF)
+    val addTimeR = client.query(TimeAdd(Epoch(0, TimeUnit.Second), 1, TimeUnit.Day)).futureValue
     addTimeR.to[Instant].get shouldBe Instant.ofEpochMilli(0).plus(1, ChronoUnit.DAYS)
 
-    val addDateF = client.query(TimeAdd(Date("1970-01-01"), 1, TimeUnit.Day))
-    val addDateR = await(addDateF)
+    val addDateR = client.query(TimeAdd(Date("1970-01-01"), 1, TimeUnit.Day)).futureValue
     addDateR.to[LocalDate].get shouldBe LocalDate.ofEpochDay(1)
 
-    val subTimeF = client.query(TimeSubtract(Epoch(0, TimeUnit.Second), 1, TimeUnit.Day))
-    val subTimeR = await(subTimeF)
+    val subTimeR = client.query(TimeSubtract(Epoch(0, TimeUnit.Second), 1, TimeUnit.Day)).futureValue
     subTimeR.to[Instant].get shouldBe Instant.ofEpochMilli(0).minus(1, ChronoUnit.DAYS)
 
-    val subDateF = client.query(TimeSubtract(Date("1970-01-01"), 1, TimeUnit.Day))
-    val subDateR = await(subDateF)
+    val subDateR = client.query(TimeSubtract(Date("1970-01-01"), 1, TimeUnit.Day)).futureValue
     subDateR.to[LocalDate].get shouldBe LocalDate.ofEpochDay(-1)
 
-    val diffTimeF = client.query(TimeDiff(Epoch(0, TimeUnit.Second), Epoch(1, TimeUnit.Second), TimeUnit.Second))
-    val diffTimeR = await(diffTimeF)
+    val diffTimeR = client.query(TimeDiff(Epoch(0, TimeUnit.Second), Epoch(1, TimeUnit.Second), TimeUnit.Second)).futureValue
     diffTimeR.to[Long].get should equal (1)
 
-    val diffDateF = client.query(TimeDiff(Date("1970-01-01"), Date("1970-01-02"), TimeUnit.Day))
-    val diffDateR = await(diffDateF)
+    val diffDateR = client.query(TimeDiff(Date("1970-01-01"), Date("1970-01-02"), TimeUnit.Day)).futureValue
     diffDateR.to[Long].get should equal (1)
   }
 
   it should "test now function" in {
-    await(client.query(Equals(Now(), Time("now")))) shouldBe TrueV
+    client.query(Equals(Now(), Time("now"))).futureValue shouldBe TrueV
 
-    val t1 = await(client.query(Now()))
-    val t2 = await(client.query(Now()))
-    await(client.query(LTE(t1, t2, Now()))) shouldBe TrueV
+    val t1 = client.query(Now()).futureValue
+    val t2 = client.query(Now()).futureValue
+    client.query(LTE(t1, t2, Now())).futureValue shouldBe TrueV
   }
 
    it should "test authentication functions" in {
-      val createF = client.query(Create(Collection("spells"), Obj("credentials" -> Obj("password" -> "abcdefg"))))
-      val createR = await(createF)
+      val createR = client.query(Create(Collection("spells"), Obj("credentials" -> Obj("password" -> "abcdefg")))).futureValue
 
       // Login
-      val loginF = client.query(Login(createR(RefField), Obj("password" -> "abcdefg")))
-      val secret = await(loginF)(SecretField).get
+      val loginR = client.query(Login(createR(RefField), Obj("password" -> "abcdefg"))).futureValue
+      val secret = loginR(SecretField).get
 
       // HasIdentity
-      val hasIdentity = client.sessionWith(secret)(_.query(HasIdentity()))
-      await(hasIdentity).to[Boolean].get shouldBe true
+      val hasIdentity = client.sessionWith(secret)(_.query(HasIdentity())).futureValue
+      hasIdentity.to[Boolean].get shouldBe true
 
       // Identity
-      val identity = client.sessionWith(secret)(_.query(Identity()))
-      await(identity).to[RefV].get shouldBe createR(RefField).get
+      val identity = client.sessionWith(secret)(_.query(Identity())).futureValue
+      identity.to[RefV].get shouldBe createR(RefField).get
 
       // Logout
-      val loggedOut = client.sessionWith(secret)(_.query(Logout(false)))
-      await(loggedOut).to[Boolean].get shouldBe true
+      val loggedOut = client.sessionWith(secret)(_.query(Logout(false))).futureValue
+      loggedOut.to[Boolean].get shouldBe true
 
       // Identify
-      val identifyF = client.query(Identify(createR(RefField), "abcdefg"))
-      val identifyR = await(identifyF)
+      val identifyR = client.query(Identify(createR(RefField), "abcdefg")).futureValue
       identifyR.to[Boolean].get shouldBe true
       }
 
@@ -963,7 +860,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val otherClient = client.sessionClient(config("root_token"))
 
     try
-      await(otherClient.query("echo string")).to[String].get shouldBe "echo string"
+      otherClient.query("echo string").futureValue.to[String].get shouldBe "echo string"
     finally
       otherClient.close()
   }
@@ -977,42 +874,42 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "find key by secret" in {
-    val key = await(rootClient.query(CreateKey(Obj("database" -> Database(testDbName), "role" -> "admin"))))
+    val key = rootClient.query(CreateKey(Obj("database" -> Database(testDbName), "role" -> "admin"))).futureValue
 
-    await(rootClient.query(KeyFromSecret(key(SecretField).get))) should equal(await(rootClient.query(Get(key(RefField).get))))
+    rootClient.query(KeyFromSecret(key(SecretField).get)).futureValue should equal (rootClient.query(Get(key(RefField).get)).futureValue)
   }
 
   it should "create a function" in {
     val query = Query((a, b) => Concat(Arr(a, b), "/"))
 
-    await(client.query(CreateFunction(Obj("name" -> "a_function", "body" -> query))))
+    client.query(CreateFunction(Obj("name" -> "a_function", "body" -> query))).futureValue
 
-    await(client.query(Exists(Function("a_function")))).to[Boolean].get shouldBe true
+    (client.query(Exists(Function("a_function"))).futureValue).to[Boolean].get shouldBe true
   }
 
   it should "call a function" in  {
     val query = Query((a, b) => Concat(Arr(a, b), "/"))
 
-    await(client.query(CreateFunction(Obj("name" -> "concat_with_slash", "body" -> query))))
+    client.query(CreateFunction(Obj("name" -> "concat_with_slash", "body" -> query))).futureValue
 
-    await(client.query(Call(Function("concat_with_slash"), "a", "b"))).to[String].get shouldBe "a/b"
+    (client.query(Call(Function("concat_with_slash"), "a", "b")).futureValue).to[String].get shouldBe "a/b"
   }
 
   it should "parse function errors" in {
-    val err = the[BadRequestException] thrownBy {
-      await(client.query(
-        CreateFunction(Obj(
-          "name" -> "function_with_abort",
-          "body" -> Query(Lambda("_", Abort("this function failed")))
-        ))
+    client.query(
+      CreateFunction(Obj(
+        "name" -> "function_with_abort",
+        "body" -> Query(Lambda("_", Abort("this function failed")))
       ))
-      await(client.query(Call(Function("function_with_abort"))))
-    }
+    ).futureValue
 
+    val err = client.query(Call(Function("function_with_abort"))).failed.futureValue
+
+    err shouldBe a[BadRequestException]
     err.getMessage should include(
       "call error: Calling the function resulted in an error.")
 
-    val cause = err.errors.head.cause.head
+    val cause = err.asInstanceOf[BadRequestException].errors.head.cause.head
     cause.code shouldEqual "transaction aborted"
     cause.description shouldEqual "this function failed"
   }
@@ -1020,30 +917,30 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "create a role" in {
     val name = s"a_role_${aRandomString}"
 
-    await(rootClient.query(CreateRole(Obj(
+    rootClient.query(CreateRole(Obj(
       "name" -> name,
       "privileges" -> Obj(
         "resource" -> Collections(),
         "actions" -> Obj("read" -> true)
       )
-    ))))
+    ))).futureValue
 
-    await(rootClient.query(Exists(Role(name)))).to[Boolean].get shouldBe true
+    (rootClient.query(Exists(Role(name))).futureValue).to[Boolean].get shouldBe true
   }
 
   it should "read a role from a nested database" in {
     val childCli = createNewDatabase(adminClient, "db-for-roles")
 
-    await(childCli.query(CreateRole(Obj(
+    childCli.query(CreateRole(Obj(
       "name" -> "a_role",
       "privileges" -> Obj(
         "resource" -> Collections(),
         "actions" -> Obj("read" -> true)
       )
-    ))))
+    ))).futureValue
 
-    await(childCli.query(Paginate(Roles())))(PageRefs).get shouldBe Seq(RefV("a_role", Native.Roles))
-    await(adminClient.query(Paginate(Roles(Database("db-for-roles")))))(PageRefs).get shouldBe
+    (childCli.query(Paginate(Roles())).futureValue).apply(PageRefs).get shouldBe Seq(RefV("a_role", Native.Roles))
+    (adminClient.query(Paginate(Roles(Database("db-for-roles")))).futureValue).apply(PageRefs).get shouldBe
       Seq(RefV("a_role", Native.Roles, RefV("db-for-roles", Native.Databases)))
   }
 
@@ -1054,14 +951,14 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val db1 = createNewDatabase(adminClient, db1Name)
     val db2 = createNewDatabase(adminClient, db2Name)
-    await(db2.query(CreateCollection(Obj("name" -> clsName))))
+    db2.query(CreateCollection(Obj("name" -> clsName))).futureValue
 
-    await(db1.query(Paginate(Databases())))(PageRefs).get shouldBe empty
+    (db1.query(Paginate(Databases())).futureValue).apply(PageRefs).get shouldBe empty
 
-    await(adminClient.query(MoveDatabase(Database(db2Name), Database(db1Name))))
+    adminClient.query(MoveDatabase(Database(db2Name), Database(db1Name))).futureValue
 
-    await(db1.query(Paginate(Databases())))(PageRefs).get shouldBe List(RefV(db2Name, Native.Databases))
-    await(db1.query(Paginate(Collections(Database(db2Name)))))(PageRefs).get shouldBe List(RefV(clsName, Native.Collections, RefV(db2Name, Native.Databases)))
+    (db1.query(Paginate(Databases())).futureValue).apply(PageRefs).get shouldBe List(RefV(db2Name, Native.Databases))
+    (db1.query(Paginate(Collections(Database(db2Name)))).futureValue).apply(PageRefs).get shouldBe List(RefV(clsName, Native.Collections, RefV(db2Name, Native.Databases)))
   }
 
   case class Spell(name: String, element: Either[String, Seq[String]], cost: Option[Long])
@@ -1073,58 +970,58 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val magicMissile = Spell("Magic Missile", Left("arcane"), Some(10))
     val faerieFire = Spell("Faerie Fire", Right(Seq("arcane", "nature")), Some(10))
 
-    val masterSummonCreated = await(client.query(Create(Collection("spells"), Obj("data" -> masterSummon))))
+    val masterSummonCreated = client.query(Create(Collection("spells"), Obj("data" -> masterSummon))).futureValue
     masterSummonCreated("data").to[Spell].get shouldBe masterSummon
 
-    val spells = await(client.query(Map(Paginate(Match(Index("spells_by_element"), "arcane")), Lambda(x => Select("data", Get(x))))))("data").get
-    spells.to[Set[Spell]].get shouldBe Set(magicMissile, faerieFire)
+    val spells = client.query(Map(Paginate(Match(Index("spells_by_element"), "arcane")), Lambda(x => Select("data", Get(x))))).futureValue
+    spells("data").get.to[Set[Spell]].get shouldBe Set(magicMissile, faerieFire)
   }
 
   it should "create collection in a nested database" in {
     val client1 = createNewDatabase(adminClient, "parent-database")
     createNewDatabase(client1, "child-database")
 
-    val key = await(client1.query(CreateKey(Obj("database" -> Database("child-database"), "role" -> "server"))))
+    val key = client1.query(CreateKey(Obj("database" -> Database("child-database"), "role" -> "server"))).futureValue
 
     val client2 = FaunaClient(secret = key(SecretField).get, endpoint = config("root_url"))
 
-    await(client2.query(CreateCollection(Obj("name" -> "a_collection"))))
+    client2.query(CreateCollection(Obj("name" -> "a_collection"))).futureValue
 
     val nestedDatabase = Database("child-database", Database("parent-database"))
 
-    await(client.query(Exists(Collection("a_collection", nestedDatabase)))).to[Boolean].get shouldBe true
+    (client.query(Exists(Collection("a_collection", nestedDatabase))).futureValue).to[Boolean].get shouldBe true
 
-    val allCollections = await(client.query(Paginate(Collections(nestedDatabase))))("data")
-    allCollections.to[List[RefV]].get shouldBe List(RefV("a_collection", Native.Collections, RefV("child-database", Native.Databases, RefV("parent-database", Native.Databases))))
+    val allCollections = client.query(Paginate(Collections(nestedDatabase))).futureValue
+    allCollections("data").to[List[RefV]].get shouldBe List(RefV("a_collection", Native.Collections, RefV("child-database", Native.Databases, RefV("parent-database", Native.Databases))))
   }
 
   it should "test for keys in nested database" in {
     val client = createNewDatabase(adminClient, "db-for-keys")
 
-    await(client.query(CreateDatabase(Obj("name" -> "db-test"))))
+    client.query(CreateDatabase(Obj("name" -> "db-test"))).futureValue
 
-    val serverKey = await(client.query(CreateKey(Obj("database" -> Database("db-test"), "role" -> "server"))))("ref").get
-    val adminKey = await(client.query(CreateKey(Obj("database" -> Database("db-test"), "role" -> "admin"))))("ref").get
+    val serverKey = (client.query(CreateKey(Obj("database" -> Database("db-test"), "role" -> "server"))).futureValue).apply("ref").get
+    val adminKey = (client.query(CreateKey(Obj("database" -> Database("db-test"), "role" -> "admin"))).futureValue).apply("ref").get
 
-    await(client.query(Paginate(Keys())))("data").to[List[Value]].get shouldBe List(serverKey, adminKey)
+    (client.query(Paginate(Keys())).futureValue).apply("data").to[List[Value]].get shouldBe List(serverKey, adminKey)
 
-    await(adminClient.query(Paginate(Keys(Database("db-for-keys")))))("data").to[List[Value]].get shouldBe List(serverKey, adminKey)
+    (adminClient.query(Paginate(Keys(Database("db-for-keys")))).futureValue).apply("data").to[List[Value]].get shouldBe List(serverKey, adminKey)
   }
 
   it should "create recursive refs from string" in {
-    await(client.query(Ref("collections/widget/123"))) shouldBe RefV("123", RefV("widget", Native.Collections))
+    client.query(Ref("collections/widget/123")).futureValue shouldBe RefV("123", RefV("widget", Native.Collections))
   }
 
   it should "not break do with one element" in {
-    await(client.query(Do(1))).to[Long].get shouldBe 1
-    await(client.query(Do(1, 2))).to[Long].get shouldBe 2
-    await(client.query(Do(Arr(1, 2)))).to[Array[Long]].get shouldBe Array(1L, 2L)
+    (client.query(Do(1)).futureValue).to[Long].get shouldBe 1
+    (client.query(Do(1, 2)).futureValue).to[Long].get shouldBe 2
+    (client.query(Do(Arr(1, 2))).futureValue).to[Array[Long]].get shouldBe Array(1L, 2L)
   }
 
   it should "parse complex index" in {
-    await(client.query(CreateCollection(Obj("name" -> "reservations"))))
+    client.query(CreateCollection(Obj("name" -> "reservations"))).futureValue
 
-    val indexF = client.query(CreateIndex(Obj(
+    val index = client.query(CreateIndex(Obj(
       "name" -> "reservations_by_lastName",
       "source" -> Obj(
         "class" -> Class("reservations"),
@@ -1140,47 +1037,46 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
         Obj("field" -> Arr("ref"))
       ),
       "active" -> true
-    )))
+    ))).futureValue
 
-    val index = await(indexF)
     index("name").get shouldBe StringV("reservations_by_lastName")
   }
 
   it should "merge objects" in {
     //empty object
-    await(client.query(
+    client.query(
       Merge(
         Obj(),
         Obj("x" -> 10, "y" -> 20)
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20)
 
     //adds field
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20),
         Obj("z" -> 30)
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
 
     //replace field
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20, "z" -> -1),
         Obj("z" -> 30)
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
 
     //remove field
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20, "z" -> -1),
         Obj("z" -> Null())
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20)
 
     //merge multiple objects
-    await(client.query(
+    client.query(
       Merge(
         Obj(),
         Arr(
@@ -1189,43 +1085,43 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
           Obj("z" -> 30)
         )
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20, "z" -> 30)
 
     //ignore left value
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20),
         Obj("x" -> 100, "y" -> 200),
         Lambda((key, left, right) => right)
       )
-    )) shouldBe ObjectV("x" -> 100, "y" -> 200)
+    ).futureValue shouldBe ObjectV("x" -> 100, "y" -> 200)
 
     //ignore right value
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20),
         Obj("x" -> 100, "y" -> 200),
         Lambda((key, left, right) => left)
       )
-    )) shouldBe ObjectV("x" -> 10, "y" -> 20)
+    ).futureValue shouldBe ObjectV("x" -> 10, "y" -> 20)
 
     //lambda 1-arity -> return [key, leftValue, rightValue]
-    await(client.query(
+    client.query(
       Merge(
         Obj("x" -> 10, "y" -> 20),
         Obj("x" -> 100, "y" -> 200),
         Lambda(value => value)
       )
-    )) shouldBe ObjectV("x" -> ArrayV("x", 10, 100), "y" -> ArrayV("y", 20, 200))
+    ).futureValue shouldBe ObjectV("x" -> ArrayV("x", 10, 100), "y" -> ArrayV("y", 20, 200))
   }
 
   it should "to_object" in {
-    await(client.query(ToObject(Seq(("k0", 10), ("k1", 20))))) shouldBe ObjectV("k0" -> 10, "k1" -> 20)
+    client.query(ToObject(Seq(("k0", 10), ("k1", 20)))).futureValue shouldBe ObjectV("k0" -> 10, "k1" -> 20)
 
     val collName = aRandomString
     val indexName = aRandomString
-    await(client.query(CreateCollection(Obj("name" -> collName))))
-    await(client.query(CreateIndex(Obj(
+    client.query(CreateCollection(Obj("name" -> collName))).futureValue
+    client.query(CreateIndex(Obj(
       "name" -> indexName,
       "source" -> Collection(collName),
       "active" -> true,
@@ -1233,24 +1129,24 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
         Obj("field" -> Arr("data", "key")),
         Obj("field" -> Arr("data", "value"))
       )
-    ))))
+    ))).futureValue
 
-    await(client.query(Do(
+    client.query(Do(
       Create(Collection(collName), Obj("data" -> Obj("key" -> "k0", "value" -> 10))),
       Create(Collection(collName), Obj("data" -> Obj("key" -> "k1", "value" -> 20)))
-    )))
+    )).futureValue
 
-    await(client.query(ToObject(Select("data", Paginate(Match(Index(indexName))))))) shouldBe ObjectV("k0" -> 10, "k1" -> 20)
+    client.query(ToObject(Select("data", Paginate(Match(Index(indexName)))))).futureValue shouldBe ObjectV("k0" -> 10, "k1" -> 20)
   }
 
   it should "to_array" in {
-    await(client.query(ToArray(Obj("k0" -> 10, "k1" -> 20)))) shouldBe ArrayV(("k0", 10), ("k1", 20))
+    client.query(ToArray(Obj("k0" -> 10, "k1" -> 20))).futureValue shouldBe ArrayV(("k0", 10), ("k1", 20))
   }
 
   it should "to_object/to_array" in {
     val obj = ObjectV("k0" -> 10, "k1" -> 20)
 
-    await(client.query(ToObject(ToArray(obj)))) shouldBe obj
+    client.query(ToObject(ToArray(obj))).futureValue shouldBe obj
   }
 
   it should "reduce collections" in {
@@ -1259,8 +1155,8 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val values = Arr((1 to 100).map(i => i: Expr): _*)
 
-    await(client.query(CreateCollection(Obj("name" -> collName))))
-    await(client.query(CreateIndex(Obj(
+    client.query(CreateCollection(Obj("name" -> collName))).futureValue
+    client.query(CreateIndex(Obj(
       "name" -> indexName,
       "source" -> Collection(collName),
       "active" -> true,
@@ -1268,43 +1164,43 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
          Obj("field" -> Arr("data", "value")),
          Obj("field" -> Arr("data", "foo"))
        )
-    ))))
+    ))).futureValue
 
-    await(client.query(
+    client.query(
       Foreach(
         values,
         Lambda(i => Create(Collection(collName), Obj(
           "data" -> Obj("value" -> i, "foo" -> "bar")
         )))
       )
-    ))
+    ).futureValue
 
     //array
-    await(client.query(
+    (client.query(
       Reduce(
         Lambda((acc, i) => Add(acc, i)),
         10,
         values
       )
-    )).to[Long].get shouldBe 5060L
+    ).futureValue).to[Long].get shouldBe 5060L
 
     //page
-    await(client.query(
+    (client.query(
       Reduce(
         Lambda((acc, i) => Add(acc, Select(0, i))),
         10,
         Paginate(Match(Index(indexName)), size = 100)
       )
-    ))("data").to[Seq[Long]].get shouldBe Seq(5060L)
+    ).futureValue).apply("data").to[Seq[Long]].get shouldBe Seq(5060L)
 
     //set
-    await(client.query(
+    (client.query(
       Reduce(
         Lambda((acc, i) => Add(acc, Select(0, i))),
         10,
         Match(Index(indexName))
       )
-    )).to[Long].get shouldBe 5060L
+    ).futureValue).to[Long].get shouldBe 5060L
   }
 
   it should "count/sum/mean collections" in {
@@ -1313,64 +1209,64 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val values = Arr((1 to 100).map(i => i: Expr): _*)
 
-    await(client.query(CreateCollection(Obj("name" -> collName))))
-    await(client.query(CreateIndex(Obj(
+    client.query(CreateCollection(Obj("name" -> collName))).futureValue
+    client.query(CreateIndex(Obj(
       "name" -> indexName,
       "source" -> Collection(collName),
       "active" -> true,
       "values" -> Arr(
         Obj("field" -> Arr("data", "value"))
       )
-    ))))
+    ))).futureValue
 
-    await(client.query(
+    client.query(
       Foreach(
         values,
         Lambda(i => Create(Collection(collName), Obj(
           "data" -> Obj("value" -> i)
         )))
       )
-    ))
+    ).futureValue
 
     //array
-    await(client.query(
+    client.query(
       Arr(
         Sum(values),
         Count(values),
         Mean(values)
       )
-    )) shouldBe ArrayV(5050L, 100L, 50.5d)
+    ).futureValue shouldBe ArrayV(5050L, 100L, 50.5d)
 
     //sets
-    await(client.query(
+    client.query(
       Arr(
         Sum(Match(Index(indexName))),
         Count(Match(Index(indexName))),
         Mean(Match(Index(indexName)))
       )
-    )) shouldBe ArrayV(5050L, 100L, 50.5d)
+    ).futureValue shouldBe ArrayV(5050L, 100L, 50.5d)
 
     //pages
-    await(client.query(
+    client.query(
       Arr(
         Select(Path("data", 0), Sum(Paginate(Match(Index(indexName)), size = 100))),
         Select(Path("data", 0), Count(Paginate(Match(Index(indexName)), size = 100))),
         Select(Path("data", 0), Mean(Paginate(Match(Index(indexName)), size = 100)))
       )
-    )) shouldBe ArrayV(5050L, 100L, 50.5d)
+    ).futureValue shouldBe ArrayV(5050L, 100L, 50.5d)
   }
 
   it should "all/any" in {
-    val coll = await(client.query(CreateCollection(Obj("name" -> aRandomString))))
-    val index = await(client.query(CreateIndex(Obj(
+    val coll = client.query(CreateCollection(Obj("name" -> aRandomString))).futureValue
+    val index = client.query(CreateIndex(Obj(
       "name" -> aRandomString,
       "source" -> coll("ref"),
       "active" -> true,
       "terms" -> Arr(Obj("field" -> Arr("data", "foo"))),
       "values" -> Arr(Obj("field" -> Arr("data", "value")))
-    ))))
+    ))).futureValue
 
-    await(client.query(Do(
+    client.query(Do(
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "true", "value" -> true))),
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "true", "value" -> true))),
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "true", "value" -> true))),
@@ -1383,41 +1279,41 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "mixed", "value" -> false))),
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "mixed", "value" -> true))),
       Create(coll("ref"), Obj("data" -> Obj("foo" -> "mixed", "value" -> false)))
-    )))
+    )).futureValue
 
     //all: array
-    await(client.query(All(Arr(true, true, true)))) shouldBe TrueV
-    await(client.query(All(Arr(true, false, true)))) shouldBe FalseV
+    client.query(All(Arr(true, true, true))).futureValue shouldBe TrueV
+    client.query(All(Arr(true, false, true))).futureValue shouldBe FalseV
 
     //all: page
-    await(client.query(All(Paginate(Match(index("ref"), "true"))))) shouldBe ObjectV("data" -> ArrayV(TrueV))
-    await(client.query(All(Paginate(Match(index("ref"), "false"))))) shouldBe ObjectV("data" -> ArrayV(FalseV))
-    await(client.query(All(Paginate(Match(index("ref"), "mixed"))))) shouldBe ObjectV("data" -> ArrayV(FalseV))
+    client.query(All(Paginate(Match(index("ref"), "true")))).futureValue shouldBe ObjectV("data" -> ArrayV(TrueV))
+    client.query(All(Paginate(Match(index("ref"), "false")))).futureValue shouldBe ObjectV("data" -> ArrayV(FalseV))
+    client.query(All(Paginate(Match(index("ref"), "mixed")))).futureValue shouldBe ObjectV("data" -> ArrayV(FalseV))
 
     //all: set
-    await(client.query(All(Match(index("ref"), "true")))) shouldBe TrueV
-    await(client.query(All(Match(index("ref"), "false")))) shouldBe FalseV
-    await(client.query(All(Match(index("ref"), "mixed")))) shouldBe FalseV
+    client.query(All(Match(index("ref"), "true"))).futureValue shouldBe TrueV
+    client.query(All(Match(index("ref"), "false"))).futureValue shouldBe FalseV
+    client.query(All(Match(index("ref"), "mixed"))).futureValue shouldBe FalseV
 
     //any: array
-    await(client.query(Any(Arr(false, false, false)))) shouldBe FalseV
-    await(client.query(Any(Arr(true, false, true)))) shouldBe TrueV
+    client.query(Any(Arr(false, false, false))).futureValue shouldBe FalseV
+    client.query(Any(Arr(true, false, true))).futureValue shouldBe TrueV
 
     //any: page
-    await(client.query(Any(Paginate(Match(index("ref"), "true"))))) shouldBe ObjectV("data" -> ArrayV(TrueV))
-    await(client.query(Any(Paginate(Match(index("ref"), "false"))))) shouldBe ObjectV("data" -> ArrayV(FalseV))
-    await(client.query(Any(Paginate(Match(index("ref"), "mixed"))))) shouldBe ObjectV("data" -> ArrayV(TrueV))
+    client.query(Any(Paginate(Match(index("ref"), "true")))).futureValue shouldBe ObjectV("data" -> ArrayV(TrueV))
+    client.query(Any(Paginate(Match(index("ref"), "false")))).futureValue shouldBe ObjectV("data" -> ArrayV(FalseV))
+    client.query(Any(Paginate(Match(index("ref"), "mixed")))).futureValue shouldBe ObjectV("data" -> ArrayV(TrueV))
 
     //any: set
-    await(client.query(Any(Match(index("ref"), "true")))) shouldBe TrueV
-    await(client.query(Any(Match(index("ref"), "false")))) shouldBe FalseV
-    await(client.query(Any(Match(index("ref"), "mixed")))) shouldBe TrueV
+    client.query(Any(Match(index("ref"), "true"))).futureValue shouldBe TrueV
+    client.query(Any(Match(index("ref"), "false"))).futureValue shouldBe FalseV
+    client.query(Any(Match(index("ref"), "mixed"))).futureValue shouldBe TrueV
   }
 
   it should "range" in {
-    val col = await(client.query(CreateCollection(Obj("name" -> aRandomString(size = 10)))))
+    val col = client.query(CreateCollection(Obj("name" -> aRandomString(size = 10)))).futureValue
 
-    val index = await(client.query(CreateIndex(Obj(
+    val index = client.query(CreateIndex(Obj(
       "name" -> aRandomString(size = 10),
       "source" -> col("ref").get,
       "values" -> Arr(
@@ -1425,9 +1321,9 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
         Obj("field" -> "ref"),
       ),
       "active" -> true
-    ))))
+    ))).futureValue
 
-    await(client.query(Foreach(
+    client.query(Foreach(
       (1 to 20).toList,
       Lambda(i =>
         Create(
@@ -1435,12 +1331,12 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
           Obj("data" -> Obj("value" -> i))
         )
       )
-    )))
+    )).futureValue
 
     def query(set: Expr) =
-      await(client.query(Select("data",
+      (client.query(Select("data",
         Map(Paginate(set), Lambda((value, ref) => value))
-      ))).to[List[Int]].get
+      )).futureValue).to[List[Int]].get
 
     val m = Match(index("ref").get)
     query(Range(m, 3, 7)) shouldBe (3 to 7).toList
@@ -1450,15 +1346,15 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "type check" in {
-    val coll = await(client.query(CreateCollection(Obj("name" -> aRandomString))))("ref").get
-    val index = await(client.query(CreateIndex(Obj("name" -> aRandomString, "source" -> coll, "active" -> true))))("ref").get
-    val doc = await(client.query(Create(coll, Obj("credentials" -> Obj("password" -> "sekret")))))("ref").get
-    val db = await(adminClient.query(CreateDatabase(Obj("name" -> aRandomString))))("ref").get
-    val fn = await(client.query(CreateFunction(Obj("name" -> aRandomString, "body" -> Query(x => x)))))("ref").get
-    val key = await(adminClient.query(CreateKey(Obj("database" -> db, "role" -> "admin"))))("ref").get
-    val tok = await(client.query(Login(doc, Obj("password" -> "sekret"))))
-    val role = await(adminClient.query(CreateRole(Obj("name" -> aRandomString, "membership" -> Arr(), "privileges" -> Arr()))))("ref").get
-    val cred = await(client.sessionWith(tok(SecretField).get) { c => c.query(Get(Ref("credentials/self"))) })("ref").get
+    val coll = (client.query(CreateCollection(Obj("name" -> aRandomString))).futureValue).apply("ref").get
+    val index = (client.query(CreateIndex(Obj("name" -> aRandomString, "source" -> coll, "active" -> true))).futureValue).apply("ref").get
+    val doc = (client.query(Create(coll, Obj("credentials" -> Obj("password" -> "sekret")))).futureValue).apply("ref").get
+    val db = (adminClient.query(CreateDatabase(Obj("name" -> aRandomString))).futureValue).apply("ref").get
+    val fn = (client.query(CreateFunction(Obj("name" -> aRandomString, "body" -> Query(x => x)))).futureValue).apply("ref").get
+    val key = (adminClient.query(CreateKey(Obj("database" -> db, "role" -> "admin"))).futureValue).apply("ref").get
+    val tok = client.query(Login(doc, Obj("password" -> "sekret"))).futureValue
+    val role = (adminClient.query(CreateRole(Obj("name" -> aRandomString, "membership" -> Arr(), "privileges" -> Arr()))).futureValue).apply("ref").get
+    val cred = (client.sessionWith(tok(SecretField).get) { c => c.query(Get(Ref("credentials/self"))) }.futureValue).apply("ref").get
     val token = tok("ref").get
 
     val trueExprs = Seq(
@@ -1505,7 +1401,7 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
       IsRole(Get(role))
     )
 
-    await(adminClient.query(trueExprs)) shouldBe Seq.fill(trueExprs.size)(TrueV)
+    adminClient.query(trueExprs).futureValue shouldBe Seq.fill(trueExprs.size)(TrueV)
 
     val falseExprs = Seq(
       IsNumber("string"),
@@ -1547,19 +1443,19 @@ class ClientSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
       IsRole(Get(index))
     )
 
-    await(adminClient.query(falseExprs)) shouldBe Seq.fill(falseExprs.size)(FalseV)
+    adminClient.query(falseExprs).futureValue shouldBe Seq.fill(falseExprs.size)(FalseV)
   }
 
   it should "retrieve documents from a collection" in {
-    val coll = await(client.query(CreateCollection(Obj("name" -> aRandomString))))("ref").get
-    for (i <- 1 to 10) await(client.query(Create(coll, Obj())))
-    val docs = await(client.query(Paginate(Documents(coll))))
+    val coll = (client.query(CreateCollection(Obj("name" -> aRandomString))).futureValue).apply("ref").get
+    for (i <- 1 to 10) client.query(Create(coll, Obj())).futureValue
+    val docs = client.query(Paginate(Documents(coll))).futureValue
     docs("data").to[Seq[Value]].get should have size 10
   }
 
   def createNewDatabase(client: FaunaClient, name: String): FaunaClient = {
-    await(client.query(CreateDatabase(Obj("name" -> name))))
-    val key = await(client.query(CreateKey(Obj("database" -> Database(name), "role" -> "admin"))))
+    client.query(CreateDatabase(Obj("name" -> name))).futureValue
+    val key = client.query(CreateKey(Obj("database" -> Database(name), "role" -> "admin"))).futureValue
     FaunaClient(secret = key(SecretField).get, endpoint = config("root_url"))
   }
 }


### PR DESCRIPTION
[DRV-206](https://faunadb.atlassian.net/browse/DRV-206)

The majority of the changes in this PR can be boiled down to replacing `await` for `futureValue`.  As a result, this will allows ScalaTest to give us a much better error response in case one of the tests fails.