### PR TITLE
Move publish settings to root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 lazy val `faunadb-jvm` =
   (project in file("."))
-    .settings(Settings.faunadbJvmSettings)
+    .settings(Settings.rootSettings: _*)
     .aggregate(`faunadb-common`, `faunadb-java`, `faunadb-scala`)
 
 lazy val `faunadb-common` =
   project
-    .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbCommonSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbCommon)
@@ -13,7 +12,6 @@ lazy val `faunadb-common` =
 lazy val `faunadb-java` =
   project
     .dependsOn(`faunadb-common`)
-    .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbJavaSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbJava)
@@ -21,6 +19,5 @@ lazy val `faunadb-java` =
 lazy val `faunadb-scala` =
   project
     .dependsOn(`faunadb-common`)
-    .settings(Settings.commonSettings: _*)
     .settings(Settings.faunadbScalaSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbScala(scalaVersion.value))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,32 +23,6 @@ object Settings {
   lazy val scalaApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-scala/api/"
   lazy val javaApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-java/api/"
 
-  lazy val commonSettings =
-    buildSettings ++
-    publishSettings
-
-  lazy val javaCommonSettings = Seq(
-    crossScalaVersions := Seq(scala212),
-    crossPaths := false,
-    autoScalaLibrary := false,
-
-    exportJars := true,
-
-    coverageEnabled := false,
-
-    javacOptions ++= Seq(
-      "-source", "1.8", "-target", "1.8"
-    ),
-
-    javacOptions in (Compile, doc) := Seq(
-      "-source", "1.8",
-      "-link", javaDocUrl,
-      "-link", jacksonDocUrl,
-      "-link", metricsDocUrl,
-      "-link", nettyClientDocUrl
-    )
-  )
-
   lazy val buildSettings = Seq(
     organization := "com.faunadb",
     version := driverVersion,
@@ -95,11 +69,36 @@ object Settings {
     pgpPublicRing := file(sys.env.getOrElse("GPG_PUBLIC_KEY", ""))
   )
 
-  lazy val faunadbJvmSettings = Seq(
-    // crossScalaVersions must be set to Nil on the aggregating project
-    crossScalaVersions := Nil,
-    publish / skip := true
+  lazy val javaCommonSettings = Seq(
+    crossScalaVersions := Seq(scala212),
+    crossPaths := false,
+    autoScalaLibrary := false,
+
+    exportJars := true,
+
+    coverageEnabled := false,
+
+    javacOptions ++= Seq(
+      "-source", "1.8", "-target", "1.8"
+    ),
+
+    javacOptions in (Compile, doc) := Seq(
+      "-source", "1.8",
+      "-link", javaDocUrl,
+      "-link", jacksonDocUrl,
+      "-link", metricsDocUrl,
+      "-link", nettyClientDocUrl
+    )
   )
+
+  lazy val rootSettings =
+    buildSettings ++
+    publishSettings ++
+    Seq(
+      // crossScalaVersions must be set to Nil on the aggregating project
+      crossScalaVersions := Nil,
+      publish / skip := true
+    )
 
   lazy val faunadbCommonSettings = Seq(
     apiURL := Some(url(commonApiUrl))


### PR DESCRIPTION
`publishSettings` was moved from the _root_ project to the subprojects as part of [DRV-170](https://faunadb.atlassian.net/browse/DRV-170). Nonetheless, it seems it needs to be set on the _root_ project in order to successfully run the `sbt sonatypeRelease` command when releasing.