### PR TITLE
Include buildSettings and publishSettings in root and subprojects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,12 @@
 lazy val `faunadb-jvm` =
   (project in file("."))
+    .settings(Settings.commonSettings: _*)
     .settings(Settings.rootSettings: _*)
     .aggregate(`faunadb-common`, `faunadb-java`, `faunadb-scala`)
 
 lazy val `faunadb-common` =
   project
+    .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbCommonSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbCommon)
@@ -12,6 +14,7 @@ lazy val `faunadb-common` =
 lazy val `faunadb-java` =
   project
     .dependsOn(`faunadb-common`)
+    .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbJavaSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbJava)
@@ -19,5 +22,6 @@ lazy val `faunadb-java` =
 lazy val `faunadb-scala` =
   project
     .dependsOn(`faunadb-common`)
+    .settings(Settings.commonSettings: _*)
     .settings(Settings.faunadbScalaSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbScala(scalaVersion.value))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -91,14 +91,15 @@ object Settings {
     )
   )
 
-  lazy val rootSettings =
+  lazy val commonSettings =
     buildSettings ++
-    publishSettings ++
-    Seq(
-      // crossScalaVersions must be set to Nil on the aggregating project
-      crossScalaVersions := Nil,
-      publish / skip := true
-    )
+    publishSettings
+
+  lazy val rootSettings = Seq(
+    // crossScalaVersions must be set to Nil on the aggregating project
+    crossScalaVersions := Nil,
+    publish / skip := true
+  )
 
   lazy val faunadbCommonSettings = Seq(
     apiURL := Some(url(commonApiUrl))


### PR DESCRIPTION
Well, it looks like some settings from `buildSettings` and `publishSettings` are required both in the root and in the subprojects, so I've inclued all of them in all of the projects. Previous to [DRV-170](https://faunadb.atlassian.net/browse/DRV-170), this is how it was configured. 

Ideally, we should identify which settings actually belong to the root project and which ones to the subprojects.