### PR TITLE
DRV-264: Remove JVM driver’s 5mb network limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ commands:
 
       - run:
           name: Compile 2.11
-          command: sbt ++2.11.12 test:compile
+          command: sbt ++2.11.12 compileAll
 
       - run:
           name: Compile 2.12
-          command: sbt ++2.12.12 test:compile
+          command: sbt ++2.12.12 compileAll
 
       - save_cache:
           paths:
@@ -53,6 +53,14 @@ commands:
       - run:
           name: Test 2.12
           command: sbt ++2.12.12 coverage test coverageReport
+
+      - run:
+          name: Load Test 2.11
+          command: sbt ++2.11.12 load:test
+
+      - run:
+          name: Load Test 2.12
+          command: sbt ++2.12.12 load:test
 
       - run:
           when: always

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val `faunadb-jvm` =
 
 lazy val `faunadb-common` =
   project
+    .configs(Configs.commonConfigs: _*)
     .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbCommonSettings)
@@ -14,6 +15,7 @@ lazy val `faunadb-common` =
 lazy val `faunadb-java` =
   project
     .dependsOn(`faunadb-common`)
+    .configs(Configs.commonConfigs: _*)
     .settings(Settings.commonSettings: _*)
     .settings(Settings.javaCommonSettings: _*)
     .settings(Settings.faunadbJavaSettings)
@@ -22,6 +24,7 @@ lazy val `faunadb-java` =
 lazy val `faunadb-scala` =
   project
     .dependsOn(`faunadb-common`)
+    .configs(Configs.commonConfigs: _*)
     .settings(Settings.commonSettings: _*)
     .settings(Settings.faunadbScalaSettings)
     .settings(libraryDependencies ++= Dependencies.faunadbScala(scalaVersion.value))

--- a/faunadb-common/src/main/java/com/faunadb/common/http/HttpClient.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/http/HttpClient.java
@@ -39,7 +39,10 @@ public class HttpClient extends AbstractReferenceCounted implements AutoCloseabl
 
   private static final int WORKER_QUIET_PERIOD = 2_000;
   private static final int WORKER_TIMEOUT = 15_000;
-  private static final int MAX_CONTENT_LENGTH = 5 * 1000 * 1000;
+  // Max limits are handled on the server-side.
+  // Unbind content limit on the client-side
+  // in order to avoid mismatch issues.
+  private static final int MAX_CONTENT_LENGTH = Integer.MAX_VALUE;
 
   private final int port;
   private final String host;

--- a/faunadb-scala/src/load/scala/faunadb/FaunaClientFixture.scala
+++ b/faunadb-scala/src/load/scala/faunadb/FaunaClientFixture.scala
@@ -1,0 +1,79 @@
+package faunadb
+
+import org.scalatest.{BeforeAndAfterAll, FutureOutcome, SuiteMixin, fixture}
+import scala.concurrent.Future
+
+trait FaunaClientFixture extends SuiteMixin with BeforeAndAfterAll { self: fixture.AsyncTestSuite =>
+  private var _rootClient: FaunaClient = _
+  protected def rootClient = _rootClient
+
+  override protected def beforeAll(): Unit = {
+    val config = {
+      val rootKey = Option(System.getenv("FAUNA_ROOT_KEY")) getOrElse {
+        throw new RuntimeException("FAUNA_ROOT_KEY must defined to run tests")
+      }
+      val domain = Option(System.getenv("FAUNA_DOMAIN")) getOrElse { "db.fauna.com" }
+      val scheme = Option(System.getenv("FAUNA_SCHEME")) getOrElse { "https" }
+      val port = Option(System.getenv("FAUNA_PORT")) getOrElse { "443" }
+
+      collection.Map("root_token" -> rootKey, "root_url" -> s"${scheme}://${domain}:${port}")
+    }
+
+    _rootClient = FaunaClient(endpoint = config("root_url"), secret = config("root_token"))
+    super.beforeAll() // To be stackable, must call super.beforeAll
+  }
+
+  override type FixtureParam = FaunaClient
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    import faunadb.query._
+    import faunadb.values._
+
+    val databaseName = {
+      def removeInvalidChars(value: String): String = {
+        val validChars = """[;@+$\-_.!~%\w]+"""
+        value.filter(_.toString.matches(validChars))
+      }
+
+      val randomSuffix = RandomGenerator.aRandomString
+      val databaseName = s"$suiteName.${test.name}-$randomSuffix"
+      val databaseNameWithValidChars = removeInvalidChars(databaseName)
+      databaseNameWithValidChars
+    }
+
+    def createDatabase(): Future[Value] = {
+      rootClient.query(CreateDatabase(Obj("name" -> databaseName)))
+    }
+
+    def createSecret(): Future[String] = {
+      rootClient
+        .query(CreateKey(Obj("database" -> Database(databaseName), "role" -> "server")))
+        .map(_(Field("secret").to[String]).get)
+    }
+
+    def createFaunaClient(secret: String): Future[FaunaClient] = Future.successful {
+      rootClient.sessionClient(secret)
+    }
+
+    def deleteDatabase(): Future[Value] = rootClient.query(Delete(Database(databaseName)))
+
+    val result =
+      new FutureOutcome(for {
+        _ <- createDatabase()
+        secret <- createSecret()
+        client <- createFaunaClient(secret)
+        result <- withFixture(test.toNoArgAsyncTest(client)).toFuture
+      } yield result)
+
+    complete {
+      result
+    }.lastly {
+      deleteDatabase()
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    try super.afterAll() // To be stackable, must call super.afterAll
+    finally if (rootClient ne null) rootClient.close()
+  }
+}

--- a/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
+++ b/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
@@ -1,0 +1,76 @@
+package faunadb
+
+import faunadb.query._
+import faunadb.values._
+import org.scalatest.{Matchers, fixture}
+import scala.concurrent.Future
+
+class FaunaClientLoadSpec extends fixture.AsyncWordSpec with Matchers with FaunaClientFixture {
+
+  "When submitting query whose response is about 10 MB of size, it" should {
+    "receive the response with no errors" in { client =>
+      // Fixtures
+      val collectionName = RandomGenerator.aRandomString
+
+      val documentFieldsNumber = 1000
+      val documentValuesSize = 1000
+      val documentsNumber = 10
+
+      val largeDocument: Expr = {
+        val fields: Seq[(String, Expr)] =
+          (1 to documentFieldsNumber).map { _ =>
+            val name = RandomGenerator.aRandomString
+            val value = Expr.encode(RandomGenerator.aRandomString(documentValuesSize))
+            (name -> value)
+          }
+
+        Obj("data" -> Obj(fields: _*))
+      }
+
+      def setup(): Future[(Value, Value)] = {
+        def createCollection(): Future[Value] = client.query(CreateCollection(Obj("name" -> collectionName)))
+
+        def createDocuments(): Future[Seq[Value]] = {
+          def createDocument(): Future[Value] = client.query(Do(Create(Collection(collectionName), largeDocument), Null))
+
+          Future.sequence(
+            (1 to documentsNumber).map { _ =>
+              createDocument()
+            }
+          )
+        }
+
+        val result: Future[(Value, Value)] =
+          for {
+            createCollectionResult <- createCollection()
+            createDocumentsResult <- createDocuments()
+          } yield (createCollectionResult, createDocumentsResult)
+
+        result
+      }
+
+      def run(): Future[Value] = {
+        // Get all documents
+        client.query {
+          Map(
+            Paginate(Documents(Collection(collectionName)), size = documentsNumber),
+            Lambda(ref => Get(ref))
+          )
+        }
+      }
+
+      // Run
+      val result: Future[Value] =
+        for {
+          _ <- setup()
+          result <- run()
+        } yield result
+
+      // Verify
+      result.map(_ => succeed) // If result is returned with no errors, succeed
+    }
+  }
+
+}
+
+

--- a/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
+++ b/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
@@ -12,9 +12,11 @@ class FaunaClientLoadSpec extends fixture.AsyncWordSpec with Matchers with Fauna
       // Fixtures
       val collectionName = RandomGenerator.aRandomString
 
+      // Note: below values result in a series of
+      // documents that add up 10 MB in size as a whole
+      val documentsNumber = 10
       val documentFieldsNumber = 1000
       val documentValuesSize = 1000
-      val documentsNumber = 10
 
       val largeDocument: Expr = {
         val fields: Seq[(String, Expr)] =
@@ -67,7 +69,11 @@ class FaunaClientLoadSpec extends fixture.AsyncWordSpec with Matchers with Fauna
         } yield result
 
       // Verify
-      result.map(_ => succeed) // If result is returned with no errors, succeed
+      result.map { _ =>
+        // TODO: once DRV-250 is done, verify the
+        // X-Query-Bytes-Out HTTP Header is greater than 10 MB
+        succeed // If result is returned with no errors, succeed
+      }
     }
   }
 

--- a/faunadb-scala/src/load/scala/faunadb/RandomGenerator.scala
+++ b/faunadb-scala/src/load/scala/faunadb/RandomGenerator.scala
@@ -1,0 +1,10 @@
+package faunadb
+
+import scala.util.Random
+
+trait RandomGenerator {
+  def aRandomString: String = aRandomString(size = 10)
+  def aRandomString(size: Int): String = Random.alphanumeric.take(size).mkString
+}
+
+object RandomGenerator extends RandomGenerator

--- a/project/Configs.scala
+++ b/project/Configs.scala
@@ -1,0 +1,3 @@
+object Configs {
+  lazy val commonConfigs = Seq(Testing.LoadTest)
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -94,7 +94,9 @@ object Settings {
 
   lazy val commonSettings =
     buildSettings ++
-    publishSettings
+    publishSettings ++
+    Tasks.settings ++
+    Testing.settings
 
   lazy val rootSettings = Seq(
     // crossScalaVersions must be set to Nil on the aggregating project

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -1,0 +1,15 @@
+import sbt.Keys._
+import sbt.{TaskKey, _}
+
+object Tasks {
+
+  lazy val compileAll = TaskKey[Unit]("compile-all")
+  
+  lazy val settings =
+    Seq(
+      compileAll := (compile in Testing.LoadTest)
+        .dependsOn(compile in Test)
+        .dependsOn(compile in Compile)
+        .value)
+
+}

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -1,0 +1,27 @@
+import sbt.Keys.{baseDirectory, scalaSource, _}
+import sbt._
+
+object Testing {
+  // Configs
+  lazy val LoadTest = config("load") extend Test
+
+  // Tasks
+  lazy val testAll = TaskKey[Unit]("test-all")
+
+  // Settings
+  lazy val loadTestSettings =
+    inConfig(LoadTest)(
+      Defaults.testSettings ++
+      Seq(
+        fork in LoadTest := true,
+        parallelExecution in LoadTest := false,
+        scalaSource in LoadTest := baseDirectory.value / "src/load/scala",
+        javaSource in LoadTest := baseDirectory.value / "src/load/java")
+    )
+
+  lazy val settings =
+    loadTestSettings ++
+    Seq(testAll := (test in LoadTest).dependsOn(test in Test).value)
+
+}
+


### PR DESCRIPTION
[DRV-264](https://faunadb.atlassian.net/browse/DRV-264)

### Changes Summary
- Content response limit set to `Integer.MAX_VALUE`
- Load-Test configuration added in sbt
- Load-Test configuration added for CircleCI
- A load-test test case added for covering a response of 10 MB of size is handled successfully