### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+3.0.1
+* Upgrade to Scala 2.12.12
+* Upgrade to sbt 1.3.13
+* Remove HTTP Response content size limit
+* Define FaunaExceptions as case classes
+* Remove unused .travis.yml file
+* Remove unused AndroidManifest.xml file
+
 3.0.0
 * Add Reverse() function
 * Refactor Contains() into family of functions

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This repository contains the FaunaDB drivers for the JVM languages. Currently, J
 
 Javadocs and Scaladocs are hosted on GitHub:
 
-* [faunadb-java](http://fauna.github.io/faunadb-jvm/3.0.0/faunadb-java/api/)
-* [faunadb-scala](http://fauna.github.io/faunadb-jvm/3.0.0/faunadb-scala/api/)
+* [faunadb-java](http://fauna.github.io/faunadb-jvm/3.0.1/faunadb-java/api/)
+* [faunadb-scala](http://fauna.github.io/faunadb-jvm/3.0.1/faunadb-scala/api/)
 
 Details Documentation for each language:
 
@@ -56,7 +56,7 @@ Download from the Maven central repository:
   <dependency>
     <groupId>com.faunadb</groupId>
     <artifactId>faunadb-java</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <scope>compile</scope>
   </dependency>
   ...
@@ -103,7 +103,7 @@ public class Main {
 ##### faunadb-scala/sbt
 
 ```scala
-libraryDependencies += ("com.faunadb" %% "faunadb-scala" % "3.0.0")
+libraryDependencies += ("com.faunadb" %% "faunadb-scala" % "3.0.1")
 ```
 
 ##### Basic Usage

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ import scoverage.ScoverageSbtPlugin.autoImport._
 
 object Settings {
 
-  lazy val driverVersion = "3.0.0"
+  lazy val driverVersion = "3.0.1"
 
   lazy val scala211 = "2.11.12"
   lazy val scala212 = "2.12.12"


### PR DESCRIPTION
## Release 3.0.1

* Upgrade to Scala 2.12.12
* Upgrade to sbt 1.3.13
* Remove HTTP Response content size limit
* Define FaunaExceptions as case classes
* Remove unused .travis.yml file
* Remove unused AndroidManifest.xml file