### PR TITLE
authentication function API v4

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -40,7 +40,7 @@ import static java.lang.String.format;
  */
 public final class Connection implements AutoCloseable {
 
-  private static final String API_VERSION = "3";
+  private static final String API_VERSION = "4";
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;
   private static final URL FAUNA_ROOT;

--- a/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/query/Language.java
@@ -2180,12 +2180,42 @@ public final class Language {
   /**
    * Returns the reference associated with the authentication token used for the current request.
    *
+   * @deprecated Use CurrentIdentity() instead.
+   *
    * @return a new {@link Expr} instance
    * @see <a href="https://app.fauna.com/documentation/reference/queryapi#authentication">FaunaDB Authentication Functions</a>
    * @see #Login(Expr, Expr)
    */
+  @Deprecated
   public static Expr Identity() {
     return Fn.apply("identity", Null());
+  }
+
+  /**
+   * Returns the reference associated with the authentication token used for the current request.
+   *
+   * @return a new {@link Expr} instance
+   * @see <a href="https://app.fauna.com/documentation/reference/queryapi#authentication">FaunaDB Authentication Functions</a>
+   * @see #Login(Expr, Expr)
+   */
+  public static Expr CurrentIdentity() {
+    return Fn.apply("current_identity", Null());
+  }
+
+  /**
+   * Returns true if the authentication used for the request has an identity.
+   *
+   * @deprecated Use HasCurrentIdentity() instead.
+   *
+   * @return a new {@link Expr} instance
+   * @see <a href="https://app.fauna.com/documentation/reference/queryapi#authentication">FaunaDB Authentication Functions</a>
+   * @see #Identity()
+   * @see #Identify(Expr, Expr)
+   * @see #Login(Expr, Expr)
+   */
+  @Deprecated
+  public static Expr HasIdentity() {
+    return Fn.apply("has_identity", Null());
   }
 
   /**
@@ -2197,8 +2227,32 @@ public final class Language {
    * @see #Identify(Expr, Expr)
    * @see #Login(Expr, Expr)
    */
-  public static Expr HasIdentity() {
-    return Fn.apply("has_identity", Null());
+  public static Expr HasCurrentIdentity() {
+    return Fn.apply("has_current_identity", Null());
+  }
+
+  /**
+   * Returns the reference associated with the authentication token used for the current request.
+   *
+   * @return a new {@link Expr} instance
+   * @see <a href="https://app.fauna.com/documentation/reference/queryapi#authentication">FaunaDB Authentication Functions</a>
+   * @see #Login(Expr, Expr)
+   */
+  public static Expr CurrentToken()  {
+    return Fn.apply("current_token", Null());
+  }
+
+  /**
+   * Returns true if the authentication used for the request has a token.
+   *
+   * @return a new {@link Expr} instance
+   * @see <a href="https://app.fauna.com/documentation/reference/queryapi#authentication">FaunaDB Authentication Functions</a>
+   * @see #Identity()
+   * @see #Identify(Expr, Expr)
+   * @see #Login(Expr, Expr)
+   */
+  public static Expr HasCurrentToken()  {
+    return Fn.apply("has_current_token", Null());
   }
 
   /**

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -1181,19 +1181,6 @@ public class ClientSpec {
   }
 
   @Test
-  public void shouldEvalContainsExpression() throws Exception {
-    Value contains = query(
-      Contains(
-        Path("favorites", "foods"),
-        Obj("favorites",
-          Obj("foods",
-            Arr(Value("crunchings"), Value("munchings")))))
-    ).get();
-
-    assertThat(contains.to(BOOLEAN).get(), is(true));
-  }
-
-  @Test
   public void shouldEvalContainsPathExpression() throws Exception {
     Value contains = query(
       ContainsPath(
@@ -2081,6 +2068,30 @@ public class ClientSpec {
     try (FaunaClient sessionClient = serverClient.newSessionClient(secret)) {
       assertThat(
               sessionClient.query(Identity()).get(),
+              equalTo(createdInstance.get(REF_FIELD))
+      );
+    }
+  }
+
+  @Test
+  public void shouldTestCurrentIdentity() throws Exception {
+    Value createdInstance = serverClient.query(
+            Create(onARandomCollection(),
+                    Obj("credentials",
+                            Obj("password", Value("sekret"))))
+    ).get();
+
+    Value auth = serverClient.query(
+            Login(
+                    createdInstance.get(REF_FIELD),
+                    Obj("password", Value("sekret")))
+    ).get();
+
+    String secret = auth.get(SECRET_FIELD);
+
+    try (FaunaClient sessionClient = serverClient.newSessionClient(secret)) {
+      assertThat(
+              sessionClient.query(CurrentIdentity()).get(),
               equalTo(createdInstance.get(REF_FIELD))
       );
     }

--- a/faunadb-scala/src/main/scala/faunadb/query/package.scala
+++ b/faunadb-scala/src/main/scala/faunadb/query/package.scala
@@ -685,16 +685,50 @@ package object query {
     *
     * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
     */
+  @deprecated("use CurrentIdentity instead", "4.0.0")
   def Identity(): Expr =
     Expr(ObjectV("identity" -> NullV))
+
+  /**
+    * A CurrentIdentity expression.
+    *
+    * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
+    */
+  def CurrentIdentity(): Expr =
+    Expr(ObjectV("current_identity" -> NullV))
 
   /**
     * An HasIdentity expression.
     *
     * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
     */
+  @deprecated("use HasCurrentIdentity instead", "4.0.0")
   def HasIdentity(): Expr =
     Expr(ObjectV("has_identity" -> NullV))
+
+  /**
+    * An HasCurrentIdentity expression.
+    *
+    * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
+    */
+  def HasCurrentIdentity(): Expr =
+    Expr(ObjectV("has_current_identity" -> NullV))
+
+  /**
+    * A CurrentToken expression.
+    *
+    * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
+    */
+  def CurrentToken(): Expr =
+    Expr(ObjectV("current_token" -> NullV))
+
+  /**
+    * An HasCurrentToken expression.
+    *
+    * '''Reference''': [[https://app.fauna.com/documentation/reference/queryapi#authentication]]
+    */
+  def HasCurrentToken(): Expr =
+    Expr(ObjectV("has_current_token" -> NullV))
 
   // String Functions
 

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -680,15 +680,6 @@ class ClientSpec
     val concat2R = client.query(Concat(Arr("Magic", "Missile"), " ")).futureValue
     concat2R.to[String].get shouldBe "Magic Missile"
 
-    // Contains
-    val containsR = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings"))))).futureValue
-    containsR.to[Boolean].get shouldBe true
-
-    client.query(Contains("field", Obj("field" -> "value"))).futureValue shouldBe TrueV
-    client.query(Contains(1, Arr("value0", "value1", "value2"))).futureValue shouldBe TrueV
-
-    client.query(Contains("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value")))))).futureValue shouldBe TrueV
-
     // ContainsField
     client.query(ContainsField("foo", Obj("foo" -> "bar"))).futureValue shouldBe TrueV
     client.query(ContainsField("foo", Obj())).futureValue shouldBe FalseV
@@ -906,9 +897,17 @@ class ClientSpec
       val hasIdentity = client.sessionWith(secret)(_.query(HasIdentity())).futureValue
       hasIdentity.to[Boolean].get shouldBe true
 
+     // HasIdentity
+     val hasCurrentIdentity = client.sessionWith(secret)(_.query(HasCurrentIdentity())).futureValue
+     hasCurrentIdentity.to[Boolean].get shouldBe true
+
       // Identity
       val identity = client.sessionWith(secret)(_.query(Identity())).futureValue
       identity.to[RefV].get shouldBe createR(RefField).get
+
+      // CurrentIdentity
+      val currentIdentity = client.sessionWith(secret)(_.query(CurrentIdentity())).futureValue
+      currentIdentity.to[RefV].get shouldBe createR(RefField).get
 
       // Logout
       val loggedOut = client.sessionWith(secret)(_.query(Logout(false))).futureValue


### PR DESCRIPTION
This PR updates FQL functions for the API v4 release:

- Deprecate `Identity` and alias to `CurrentIdentity` ([Scala ticket](https://faunadb.atlassian.net/browse/DRV-276) & [Java ticket](https://faunadb.atlassian.net/browse/DRV-281))
- Deprecate `HasIdentity` and alias to `HasCurrentIdentity` ([Scala ticket](https://faunadb.atlassian.net/browse/DRV-277) & [Java ticket](https://faunadb.atlassian.net/browse/DRV-282))
- Add `CurrentToken` ([Scala ticket](https://faunadb.atlassian.net/browse/DRV-278) & [Java ticket](https://faunadb.atlassian.net/browse/DRV-283))
- Add `HasCurrentToken` ([Scala ticket](https://faunadb.atlassian.net/browse/DRV-279) & [Java ticket](https://faunadb.atlassian.net/browse/DRV-284))

### TODO

- add tests for `CurrentToken` (Java & Scala)
- add tests for `HasCurrentToken`

Update `CreateAccessProvider` will be tackled in a different PR.
