### PR TITLE
Reuse client Netty internals in ClientSpec

### DIFF
--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -1617,6 +1617,6 @@ class ClientSpec
   def createNewDatabase(client: FaunaClient, name: String): FaunaClient = {
     client.query(CreateDatabase(Obj("name" -> name))).futureValue
     val key = client.query(CreateKey(Obj("database" -> Database(name), "role" -> "admin"))).futureValue
-    FaunaClient(secret = key(SecretField).get, endpoint = config("root_url"))
+    client.sessionClient(key(SecretField).get)
   }
 }


### PR DESCRIPTION
While working for an extended period of time on the `ClientSpec` I often see the following error

```
14:33:30.794 [ForkJoinPool.commonPool-worker-5] INFO  com.faunadb.common.Connection - Request: POST http://localhost:8443: {"create_role":{"object":{"name":"a_role_cCOl02CD","privileges":{"object":{"resource":{"collections":null},"actions":{"object":{"read":true}}}}}}}. Failed: io.netty.handler.codec.EncoderException: java.lang.OutOfMemoryError: Direct buffer memory
java.util.concurrent.CompletionException: io.netty.handler.codec.EncoderException: java.lang.OutOfMemoryError: Direct buffer memory
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:331)
        at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:670)
  | => fat java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094)
	at com.faunadb.common.http.HttpClient.writeTo(HttpClient.java:244)
```

My hypothesis is that it is due to the extra Netty event-loop created in `createNewDatabase` which are never shutdown.

This PR proposes to fix the issue by using `client.sessionClient` on an existing client to reuse the existing event-loop.