### PR TITLE
DRV-301: Streaming API for scala driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ It is possible to use the [java.util.concurrent.Flow](https://docs.oracle.com/ja
 In the example below, we are capturing the 4 first messages:
 
 ```scala
+import faunadb._
+import faunadb.query._
+
 // docRef is a reference to the document for which we want to stream updates.
 // You can acquire a document reference with a query like the following, but it
 // needs to work with the documents that you have.
@@ -199,6 +202,12 @@ The [reactive-streams](http://www.reactive-streams.org/) standard offers a stron
 We can replicate the previous example using the [Monix](https://monix.io/) streaming library.
 
 ```scala
+import faunadb._
+import faunadb.query._
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import org.reactivestreams.{FlowAdapters, Publisher}
+
 // docRef is a reference to the document for which we want to stream updates.
 // You can acquire a document reference with a query like the following, but it
 // needs to work with the documents that you have.

--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -14,6 +14,7 @@ import java.net.*;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -21,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -374,6 +375,34 @@ public class Connection {
     return client.sendAsync(req, HttpResponse.BodyHandlers.ofString());
   }
 
+  public CompletableFuture<HttpResponse<Flow.Publisher<List<ByteBuffer>>>> streamRequest(HttpRequest req) {
+    return client.sendAsync(req, HttpResponse.BodyHandlers.ofPublisher());
+  }
+
+  public CompletableFuture<HttpResponse<Flow.Publisher<List<ByteBuffer>>>> performStreamRequest(String httpMethod, String path, JsonNode body,
+                                                                                                Map<String, List<String>> params) throws Exception {
+    final Timer.Context ctx = registry.timer("fauna-request").time();
+    final CompletableFuture<HttpResponse<Flow.Publisher<List<ByteBuffer>>>> rv = new CompletableFuture<>();
+
+    HttpRequest request = makeHttpRequest(httpMethod, path, Optional.of(body), params, Optional.empty(), HttpClient.Version.HTTP_2);
+
+    streamRequest(request).whenCompleteAsync((response, throwable) -> {
+      ctx.stop();
+      if (throwable != null) {
+        logFailure(request, throwable);
+        rv.completeExceptionally(throwable);
+        return;
+      }
+
+      Optional<String> txnTimeHeader = response.headers().firstValue("x-txn-time");
+      txnTimeHeader.ifPresent(s -> syncLastTxnTime(Long.parseLong(s)));
+
+      rv.complete(response);
+    });
+
+    return rv;
+  }
+
   private HttpRequest makeHttpRequest(String httpMethod, String path, Optional<JsonNode> body, Map<String, List<String>> params,
                                       Optional<Duration> requestQueryTimeout, HttpClient.Version httpVersion) throws MalformedURLException, URISyntaxException, JsonProcessingException {
     URI requestUri = URI.create(mkUrl(path));
@@ -438,11 +467,10 @@ public class Connection {
   private void logFailure(HttpRequest request, Throwable ex) {
     log.info(
       format("Request: %s %s: %s. Failed: %s",
-        request.method(), request.uri(), request.bodyPublisher().map(Object::toString).orElse("NoBody").toString(), ex.getMessage()), ex);
+        request.method(), request.uri(), request.bodyPublisher().map(Object::toString).orElse("NoBody"), ex.getMessage()), ex);
   }
 
   private static String generateAuthHeader(String authToken) {
     return "Bearer " + authToken;
   }
-
 }

--- a/faunadb-common/src/main/java/com/faunadb/common/http/ResponseBodyStringProcessor.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/http/ResponseBodyStringProcessor.java
@@ -1,0 +1,47 @@
+package com.faunadb.common.http;
+
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.stream.Collectors;
+
+public class ResponseBodyStringProcessor {
+
+    public static CompletableFuture<String> consumeBody(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response) {
+        final CompletableFuture<String> stringPromise = new CompletableFuture<>();
+        Flow.Subscriber<List<ByteBuffer>> stringBodyHandlerSubscriber = new Flow.Subscriber<>() {
+            Flow.Subscription subscription = null;
+            List<ByteBuffer> captured = new ArrayList<>();
+            @Override
+            public void onSubscribe(Flow.Subscription s) {
+                subscription = s;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(List<ByteBuffer> item) {
+                captured.addAll(item);
+                subscription.request(1);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                stringPromise.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                String text = captured.stream()
+                        .map(b -> StandardCharsets.UTF_8.decode(b).toString())
+                        .collect(Collectors.joining());
+                stringPromise.complete(text);
+            }
+        };
+        response.body().subscribe(stringBodyHandlerSubscriber);
+        return stringPromise;
+    }
+}

--- a/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
+++ b/faunadb-scala/src/load/scala/faunadb/FaunaClientLoadSpec.scala
@@ -1,12 +1,18 @@
 package faunadb
 
+import java.util
+import java.util.concurrent.Flow
+
 import faunadb.query._
 import faunadb.values._
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.wordspec.FixtureAsyncWordSpec
 import org.scalatest.matchers.should.Matchers
-import scala.concurrent.Future
 
-class FaunaClientLoadSpec extends FixtureAsyncWordSpec with Matchers with FaunaClientFixture {
+import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.concurrent.{Future, Promise}
+
+class FaunaClientLoadSpec extends FixtureAsyncWordSpec with Matchers with ScalaFutures with IntegrationPatience with FaunaClientFixture {
 
   "When submitting query whose response is about 10 MB of size, it" should {
     "receive the response with no errors" in { client =>
@@ -76,6 +82,131 @@ class FaunaClientLoadSpec extends FixtureAsyncWordSpec with Matchers with FaunaC
         succeed // If result is returned with no errors, succeed
       }
     }
+  }
+
+  "When streaming" should {
+    "buffers events if the producer is faster than the consumer" in { client =>
+      val subscriberDone = Promise[List[Value]]
+      val bufferSize = 256
+
+      // create collection
+      val collectionName = RandomGenerator.aRandomString
+      val setup = for {
+        _ <- client.query(CreateCollection(Obj("name" -> collectionName)))
+        createdDoc <- client.query(Create(Collection(collectionName), Obj("credentials" -> Obj("password" -> "abcdefg"))))
+        docRef = createdDoc("ref")
+        publisherValue <- client.stream(docRef)
+      } yield (docRef, publisherValue)
+
+      setup.flatMap { case (docRef, publisherValue) =>
+        val valueSubscriber = new Flow.Subscriber[Value] {
+          var subscription: Flow.Subscription = _
+          val captured = new util.ArrayList[Value]
+
+          override def onSubscribe(s: Flow.Subscription): Unit = {
+            subscription = s
+            subscription.request(1)
+          }
+
+          override def onNext(v: Value): Unit = {
+            if (captured.isEmpty) {
+              // update doc `bufferSize` times on `start` event
+              (1 to bufferSize).iterator
+                .map(i => s"testValue$i")
+                .foreach { uv =>
+                  // blocking call to update document sequentially
+                  client.query(Update(docRef, Obj("data" -> Obj("testField" -> uv)))).futureValue
+                }
+              captured.add(v)
+            } else {
+              captured.add(v) // capture element
+              if (captured.size > bufferSize) {
+                subscriberDone.success(captured.iterator().asScala.toList)
+                subscription.cancel()
+              }
+            }
+            subscription.request(1) // ask for more elements
+          }
+
+          override def onError(t: Throwable): Unit = subscriberDone.failure(t)
+
+          override def onComplete(): Unit = subscriberDone.failure(new IllegalStateException("not expecting the stream to complete"))
+        }
+
+        // subscribe to publisher
+        publisherValue.subscribe(valueSubscriber)
+
+        // blocking
+        subscriberDone.future.map(_.size should be(bufferSize + 1))
+      }
+    }
+
+    "handles at least 250 concurrent streams on the same document" in { client =>
+      val concurrentStreamCount = 250
+      // create collection
+      val collectionName = RandomGenerator.aRandomString
+      val setup = for {
+        _ <- client.query(CreateCollection(Obj("name" -> collectionName)))
+        createdDoc <- client.query(Create(Collection(collectionName), Obj("credentials" -> Obj("password" -> "abcdefg"))))
+        docRef = createdDoc("ref")
+        publisherValues <- Future.traverse(List.fill(concurrentStreamCount)(docRef))(ref => client.stream(ref))
+        events = publisherValues.map(testSubscriber(4, _))
+        // push 3 updates
+        _ <- client.query(Update(docRef, Obj("data" -> Obj("testField" -> "testValue1"))))
+        _ <- client.query(Update(docRef, Obj("data" -> Obj("testField" -> "testValue2"))))
+        _ <- client.query(Update(docRef, Obj("data" -> Obj("testField" -> "testValue3"))))
+        subscriberResults <- Future.sequence(events)
+      } yield subscriberResults
+
+      setup.map { subscriberResults =>
+        subscriberResults.size shouldBe concurrentStreamCount
+        subscriberResults.map {
+          case startEvent :: t1 :: t2 :: t3 :: Nil =>
+            startEvent("type").get shouldBe StringV("start")
+            startEvent("event").toOpt.isDefined shouldBe true
+
+            t1("type").get shouldBe StringV("version")
+            t1("event", "document", "data").get shouldBe ObjectV("testField" -> StringV("testValue1"))
+
+            t2("type").get shouldBe StringV("version")
+            t2("event", "document", "data").get shouldBe ObjectV("testField" -> StringV("testValue2"))
+
+            t3("type").get shouldBe StringV("version")
+            t3("event", "document", "data").get shouldBe ObjectV("testField" -> StringV("testValue3"))
+          case _ =>
+            fail("expected 4 events")
+        }
+        succeed
+      }
+    }
+  }
+
+  def testSubscriber(messageCount: Int, publisher: Flow.Publisher[Value]): Future[List[Value]] = {
+    val capturedEventsP = Promise[List[Value]]
+
+    val valueSubscriber = new Flow.Subscriber[Value] {
+      var subscription: Flow.Subscription = _
+      val captured = new util.ArrayList[Value]
+
+      override def onSubscribe(s: Flow.Subscription): Unit = {
+        subscription = s
+        subscription.request(1)
+      }
+      override def onNext(v: Value): Unit = {
+        captured.add(v)
+        if (captured.size() == messageCount) {
+          capturedEventsP.success(captured.iterator().asScala.toList)
+          subscription.cancel()
+        } else {
+          subscription.request(1)
+        }
+      }
+      override def onError(t: Throwable): Unit = capturedEventsP.failure(t)
+      override def onComplete(): Unit = capturedEventsP.failure(new IllegalStateException("not expecting the stream to complete"))
+    }
+    // subscribe to publisher
+    publisher.subscribe(valueSubscriber)
+    capturedEventsP.future
   }
 
 }

--- a/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
+++ b/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
@@ -1,0 +1,86 @@
+package faunadb.streaming
+
+import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.{Flow, SubmissionPublisher}
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import faunadb.QueryError
+import faunadb.errors.{StreamingException, UnknownException}
+import faunadb.values.{StringV, VSuccess, Value}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.util.Try
+
+private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTime: Long => Unit) extends SubmissionPublisher[Value] with Flow.Processor[util.List[ByteBuffer], Value] {
+  private val log = LoggerFactory.getLogger(getClass)
+  private var subscription: Flow.Subscription = _
+  private var subscriber: Flow.Subscriber[_ >: Value] = _
+
+  // We do not request data from the publisher until we have one subscriber
+  override def subscribe(subscriber: Flow.Subscriber[_ >: Value]): Unit = {
+    if (this.subscriber == null) {
+      this.subscriber = subscriber
+      super.subscribe(subscriber)
+      requestOne()
+    } else
+      throw new IllegalStateException("BodyValueFlowProcessor can have only one subscriber")
+  }
+
+  override def onSubscribe(subscription: Flow.Subscription): Unit =
+    this.subscription = subscription
+
+  override def onNext(item: util.List[ByteBuffer]): Unit = {
+    import java.nio.charset.StandardCharsets
+    val text = item.iterator().asScala.map(StandardCharsets.UTF_8.decode(_).toString).mkString("")
+    Try {
+      val eventJsonNode = json.readTree(text)
+      val value = json.treeToValue[Value](eventJsonNode, classOf[Value])
+
+      // syncLastTxnTime if possible
+      value("txn").to[Long].toOpt.foreach(syncLastTxnTime)
+
+      // handle error in stream
+      isUnrecoverableError(value, eventJsonNode) match {
+        case None => submit(value)
+        case Some(unrecoverableError) =>
+          subscriber.onError(unrecoverableError) // notify subscriber stream
+          subscription.cancel() // cancel subscription on the request body
+      }
+    }.recover {
+      case e: Throwable =>
+        log.error(s"could not handle event $text", e)
+        subscriber.onError(e) // notify subscriber stream
+        subscription.cancel() // cancel subscription on the request body
+    }
+
+    requestOne()
+  }
+
+  private def isUnrecoverableError(event: Value, jsonNode: JsonNode): Option[Throwable] = {
+    (event("type"), Option(jsonNode.get("event"))) match {
+      case (VSuccess(StringV("error"), _), Some(error)) =>
+        val queryError = json.treeToValue(error, classOf[QueryError])
+        val ex = new StreamingException(queryError)
+        Some(ex)
+      case (VSuccess(StringV("error"), _), None) =>
+        Some(new UnknownException(s"unknown error received for event $event", new IllegalArgumentException()))
+      case _ => None
+    }
+  }
+
+  override def onError(throwable: Throwable): Unit = {
+    log.error("unrecoverable error encountered by subscription", throwable)
+    subscriber.onError(throwable)
+  }
+
+  override def onComplete(): Unit = {
+    log.debug("subscription completed")
+    subscriber.onComplete()
+  }
+
+  private def requestOne(): Unit =
+    subscription.request(1)
+}
+

--- a/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
+++ b/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
@@ -19,6 +19,7 @@ private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTi
   private var subscriber: Flow.Subscriber[_ >: Value] = _
 
   // We do not request data from the publisher until we have one subscriber
+  // to avoid discarding events before the subscriber had the chance to subscribe.
   override def subscribe(subscriber: Flow.Subscriber[_ >: Value]): Unit = {
     if (this.subscriber == null) {
       this.subscriber = subscriber

--- a/faunadb-scala/src/main/scala/faunadb/streaming/SnapshotEventFlowProcessor.scala
+++ b/faunadb-scala/src/main/scala/faunadb/streaming/SnapshotEventFlowProcessor.scala
@@ -1,0 +1,80 @@
+package faunadb.streaming
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{Flow, SubmissionPublisher}
+
+import faunadb.values._
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+private [faunadb] class SnapshotEventFlowProcessor(loadDocument: () => Future[Value])(implicit ec: ExecutionContext)
+  extends SubmissionPublisher[Value] with Flow.Processor[Value, Value] {
+  private val log = LoggerFactory.getLogger(getClass)
+  private var subscription: Flow.Subscription = _
+  private var subscriber: Flow.Subscriber[_ >: Value] = _
+  private val initialized = new AtomicBoolean(false)
+  @volatile private var snapshotTS: Long = _
+
+  // We do not request data from the publisher until we have one subscriber
+  override def subscribe(subscriber: Flow.Subscriber[_ >: Value]): Unit = {
+    if (this.subscriber == null) {
+      this.subscriber = subscriber
+      super.subscribe(subscriber)
+      requestOne()
+    } else
+      throw new IllegalStateException("SnapshotEventFlowProcessor can have only one subscriber")
+  }
+
+  override def onSubscribe(subscription: Flow.Subscription): Unit =
+    this.subscription = subscription
+
+  override def onNext(event: Value): Unit = {
+    if (initialized.get()) {
+      val eventTS = event("txn").to[Long].get
+      if (eventTS > snapshotTS) submit(event) // ignore event older than doc. snapshot
+      requestOne()
+    } else {
+      // not initialized receiving first element
+      event("type") match {
+        case VSuccess(StringV("start"), _) =>
+          loadDocument().onComplete {
+            case Failure(exception) =>
+              onError(exception)
+              subscription.cancel()
+            case Success(documentSnapshot) =>
+              snapshotTS = documentSnapshot("ts").to[Long].get
+              // send start event first
+              submit(event)
+              // follow up with the snapshot event
+              val documentEvent = ObjectV(
+                "type" -> StringV("snapshot"),
+                "txn" -> LongV(snapshotTS.toLong),
+                "event" -> documentSnapshot)
+              submit(documentEvent)
+              initialized.set(true)
+              // only request more when we are ready in order to avoid race condition
+              requestOne()
+          }
+        case _ =>
+          onError(new IllegalArgumentException(s"Stream did not begin with a `start` event but $event"))
+          subscription.cancel()
+      }
+    }
+  }
+
+  override def onError(throwable: Throwable): Unit = {
+    log.error("unrecoverable error encountered by subscription", throwable)
+    subscriber.onError(throwable)
+  }
+
+  override def onComplete(): Unit = {
+    log.debug("subscription completed")
+    subscriber.onComplete()
+  }
+
+  private def requestOne(): Unit =
+    subscription.request(1)
+}
+

--- a/faunadb-scala/src/main/scala/faunadb/streaming/SnapshotEventFlowProcessor.scala
+++ b/faunadb-scala/src/main/scala/faunadb/streaming/SnapshotEventFlowProcessor.scala
@@ -18,6 +18,7 @@ private [faunadb] class SnapshotEventFlowProcessor(loadDocument: () => Future[Va
   @volatile private var snapshotTS: Long = _
 
   // We do not request data from the publisher until we have one subscriber
+  // to avoid discarding events before the subscriber had the chance to subscribe.
   override def subscribe(subscriber: Flow.Subscriber[_ >: Value]): Unit = {
     if (this.subscriber == null) {
       this.subscriber = subscriber

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,8 @@ object Dependencies {
     val junitInterfaceVersion        = "0.11"
     val harmcrestLibraryVersion      = "2.2"
     val junitVersion                 = "4.13"
+    val reactiveStreamsVersion       = "1.0.3"
+    val monixVersion                 = "3.3.0"
   }
 
   // Libraries
@@ -50,7 +52,9 @@ object Dependencies {
     val snakeYaml           = "org.yaml"        %  "snakeyaml"         % snakeYamlVersion         % "test"
 
     // faunadb-scala
-    val scalaTest           = "org.scalatest"   %% "scalatest"         % scalaTestVersion         % "test"
+    val scalaTest           = "org.scalatest"       %% "scalatest"         % scalaTestVersion         % "test"
+    val reactiveStreams     = "org.reactivestreams" %  "reactive-streams"  % reactiveStreamsVersion   % "test"
+    val monix               = "io.monix"            %% "monix"             % monixVersion             % "test"
   }
 
   import Compile._
@@ -73,6 +77,6 @@ object Dependencies {
   // Projects
   val faunadbCommon = jacksonCommon ++ Seq(slf4j, metrics)
   val faunadbJava = Seq(logbackClassic, snakeYaml, junit, junitInterface, harmcrestLibrary)
-  def faunadbScala(scalaVersion: String): Seq[ModuleID] = jacksonScala ++ scalaLang(scalaVersion) ++ Seq(logbackClassic, scalaTest)
+  def faunadbScala(scalaVersion: String): Seq[ModuleID] = jacksonScala ++ scalaLang(scalaVersion) ++ Seq(logbackClassic, scalaTest, reactiveStreams, monix)
 
 }


### PR DESCRIPTION
This PR is built on top of the Jdk11 client migration proposal https://github.com/fauna/faunadb-jvm/pull/270

This PR proposes a Streaming API based on the `java.concurrent.Flow` which offers a strong interoperability via the reactive-streams initiative.

### API

```scala

 /**
    * Creates a subscription to the result of the given read-only expression. When
    * executed, the expression must only perform reads and produce a single
    * streamable type, such as a reference or a version. Expressions that attempt
    * to perform writes or produce non-streamable types will result in an error.
    * Otherwise, any expression can be used to initiate a stream, including
    * user-defined function calls.
    *
    * @param expr the query to subscribe to.
    * @param fields fields to opt-in on the events.
    * @param snapshot if true the second event will be a snapshot event of the target
    * @param ec the `ExecutionContext` used to run the query asynchronously.
    * @return A [[scala.concurrent.Future]] containing a [[java.util.concurrent.Flow.Publisher]] which yields element of
    *         type [[faunadb.values.Value]]. The [[scala.concurrent.Future]] fails if the stream cannot be setup.
    */
  def stream(expr: Expr, fields: Seq[EventField] = Nil, snapshot: Boolean = false)(implicit ec: ExecutionContext): Future[Flow.Publisher[Value]]
```

The `Publisher` can be consumed manually or via a `reactive-streams` integration.

### Errors

- ~~recoverable errors are pushed as domain error events in the stream.~~
- error events stop the stream by triggering `onError` on the consumer.
- server disconnects were only tested on Linux using software TCP resets by running `ss -K dst xxx` on an active stream which stops the subscription with:

```
ERROR f.streaming.BodyValueFlowProcessor - unrecoverable error encountered by subscription
java.io.IOException: Software caused connection abort
        at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
        at java.base/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
        at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:276)
        at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:233)
        at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:223)
        at java.base/sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:358)
  | => fat java.net.http/jdk.internal.net.http.SocketTube.readAvailable(SocketTube.java:1153)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.read(SocketTube.java:821)
	at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowTask.run(SocketTube.java:175)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:198)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:271)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:224)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.signalReadable(SocketTube.java:763)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadEvent.signalEvent(SocketTube.java:941)
	at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowEvent.handle(SocketTube.java:245)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.handleEvent(HttpClientImpl.java:957)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.lambda$run$3(HttpClientImpl.java:912)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.run(HttpClientImpl.java:912)
```
 
The Java API will follow up [here](https://github.com/fauna/faunadb-jvm/pull/275) after the learnings of the Scala API.