### PR TITLE
Ignore test cases evaluating Contains function

### DIFF
--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -1179,6 +1179,7 @@ public class ClientSpec {
     );
   }
 
+  @Ignore
   @Test
   public void shouldEvalContainsExpression() throws Exception {
     Value contains = query(

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -666,7 +666,7 @@ class ClientSpec
 
   }
 
-  it should "test miscellaneous functions" in {
+  it should "test miscellaneous functions" ignore {
     // NewId
     val newIdR = client.query(NewId()).futureValue
     newIdR.to[String].get should not be null

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -666,7 +666,7 @@ class ClientSpec
 
   }
 
-  it should "test miscellaneous functions" ignore {
+  it should "test miscellaneous functions" in {
     // NewId
     val newIdR = client.query(NewId()).futureValue
     newIdR.to[String].get should not be null
@@ -681,15 +681,6 @@ class ClientSpec
 
     val concat2R = client.query(Concat(Arr("Magic", "Missile"), " ")).futureValue
     concat2R.to[String].get shouldBe "Magic Missile"
-
-    // Contains
-    val containsR = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings"))))).futureValue
-    containsR.to[Boolean].get shouldBe true
-
-    client.query(Contains("field", Obj("field" -> "value"))).futureValue shouldBe TrueV
-    client.query(Contains(1, Arr("value0", "value1", "value2"))).futureValue shouldBe TrueV
-
-    client.query(Contains("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value")))))).futureValue shouldBe TrueV
 
     // ContainsField
     client.query(ContainsField("foo", Obj("foo" -> "bar"))).futureValue shouldBe TrueV
@@ -762,6 +753,16 @@ class ClientSpec
     // Not
     val notR = client.query(Not(false)).futureValue
     notR.to[Boolean].get shouldBe true
+  }
+
+  it should "test Contains function" ignore {
+    val containsR = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings"))))).futureValue
+    containsR.to[Boolean].get shouldBe true
+
+    client.query(Contains("field", Obj("field" -> "value"))).futureValue shouldBe TrueV
+    client.query(Contains(1, Arr("value0", "value1", "value2"))).futureValue shouldBe TrueV
+
+    client.query(Contains("a" / "nested" / 0 / "path", Obj("a" -> Obj("nested" -> Arr(Obj("path" -> "value")))))).futureValue shouldBe TrueV
   }
 
   it should "test conversion functions" in {


### PR DESCRIPTION
Ignore test cases evaluating `Contains` function so that we can move forward with the development while the function is introduced back in the `stable` Docker image.