### PR TITLE
Remove core-stable CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
       - checkout
 
       - restore_cache:
-          key: sbt-cache
+          key: faunadb-jvm-v1-{{ .Branch }}-{{checksum "project/Dependencies.scala" }}
 
       - run:
           name: Compile 2.11
@@ -41,7 +41,7 @@ commands:
           command: sbt ++2.12.12 compileAll
 
       - save_cache:
-          key: sbt-cache
+          key: faunadb-jvm-v1-{{ .Branch }}-{{checksum "project/Dependencies.scala" }}
           paths:
             - "~/.ivy2/cache"
             - "~/.sbt"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
     parameters:
       version:
         type: enum
-        enum: ["stable", "nightly"]
+        enum: ["nightly"]
     resource_class: large
     docker:
       - image: circleci/openjdk:8-jdk
@@ -75,13 +75,6 @@ commands:
           path: results/
 
 jobs:
-  core-stable:
-    executor:
-      name: core
-      version: stable
-    steps:
-      - build_and_test
-
   core-nightly:
     executor:
       name: core
@@ -93,7 +86,5 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - core-stable:
-          context: faunadb-drivers
       - core-nightly:
           context: faunadb-drivers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ commands:
       - checkout
 
       - restore_cache:
-          keys:
-          - v1-deps-{{ checksum "build.sbt" }}
+          key: sbt-cache
 
       - run:
           name: Compile 2.11
@@ -42,9 +41,11 @@ commands:
           command: sbt ++2.12.12 compileAll
 
       - save_cache:
+          key: sbt-cache
           paths:
-          - ~/.ivy2
-          key: v1-deps-{{ checksum "build.sbt" }}
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"
 
       - run:
           name: Test 2.11


### PR DESCRIPTION
### Changes Summary

#### 1. Remove `core-stable` job from CircleCI `config.yml`
The `stable` image will not be updated with latest changes for the foreseeable future. Most likely the image will be replaced by some other while we redesign our CI pipeline. Remove the job for now since new features cannot be tested against it  (e.g., streaming).

#### 2. Update CircleCI cache key format 
CircleCI is broken for some of the existing PRs due to cache permissions errors. Update cache key format to fix the current issue and prevent futures ones following best practices from:
  * [Language Guide: Scala](https://circleci.com/docs/2.0/language-scala/)
  * [Caching Dependencies](https://circleci.com/docs/2.0/caching/)
  * [Clear project dependency cache](https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache)