### PR TITLE
Fix JavaDoc issues

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/http/HttpClient.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/http/HttpClient.java
@@ -125,7 +125,7 @@ public class HttpClient extends AbstractReferenceCounted implements AutoCloseabl
   /**
    * Implemented for {@link AbstractReferenceCounted}.
    *
-   * @returns ReferenceCounted
+   * @return ReferenceCounted
    */
   @Override
   public ReferenceCounted touch(Object hint) {
@@ -134,8 +134,6 @@ public class HttpClient extends AbstractReferenceCounted implements AutoCloseabl
 
   /**
    * Frees any resources held by the client. Also closes the underlying worker
-   *
-   * @throws IOException
    */
   @Override
   protected void deallocate() {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -12,9 +12,12 @@ object Settings {
   lazy val scala212 = "2.12.12"
   lazy val supportedScalaVersions = Seq(scala211, scala212)
 
+  lazy val jacksonDocVersion = "2.11"
+
   lazy val javaDocUrl = "http://docs.oracle.com/javase/7/docs/api/"
   lazy val nettyClientDocUrl = "https://netty.io/4.1/api/index.html"
-  lazy val metricsDocUrl = s"http://dropwizard.github.io/metrics/$metricsVersion/apidocs/"
+  lazy val jacksonDocUrl = s"http://fasterxml.github.io/jackson-databind/javadoc/$jacksonDocVersion/"
+  lazy val metricsDocUrl = s"https://javadoc.io/doc/io.dropwizard.metrics/metrics-core/$metricsVersion/"
 
   lazy val commonApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-common/api/"
   lazy val scalaApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-scala/api/"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -12,11 +12,8 @@ object Settings {
   lazy val scala212 = "2.12.12"
   lazy val supportedScalaVersions = Seq(scala211, scala212)
 
-  lazy val jacksonDocVersion = "2.10"
-
   lazy val javaDocUrl = "http://docs.oracle.com/javase/7/docs/api/"
   lazy val nettyClientDocUrl = "https://netty.io/4.1/api/index.html"
-  lazy val jacksonDocUrl = s"http://fasterxml.github.io/jackson-databind/javadoc/$jacksonDocVersion/"
   lazy val metricsDocUrl = s"http://dropwizard.github.io/metrics/$metricsVersion/apidocs/"
 
   lazy val commonApiUrl = s"http://fauna.github.io/faunadb-jvm/$driverVersion/faunadb-common/api/"
@@ -86,7 +83,6 @@ object Settings {
     javacOptions in (Compile, doc) := Seq(
       "-source", "1.8",
       "-link", javaDocUrl,
-      "-link", jacksonDocUrl,
       "-link", metricsDocUrl,
       "-link", nettyClientDocUrl
     )


### PR DESCRIPTION
There were some errors triggered during Java/ScalaDoc generation. In order to test, run:

```sh
sbt packageDoc
```

These fixes are required for Pronghorn.