### PR TITLE
DRV-319: introduce cleaner error for max_concurrent_streams

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -24,6 +24,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -454,6 +455,9 @@ public class FaunaClient {
       return f.whenComplete((v, ex) -> {
           if (ex instanceof ConnectException || ex instanceof TimeoutException) {
               throw new UnavailableException(ex.getMessage(), ex);
+          }
+          if (ex instanceof CompletionException && ex.getMessage().contains("too many concurrent streams")) {
+            throw new BadRequestException("the maximum number of streams has been reached for this client");
           }
       });
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -17,6 +17,7 @@ import com.faunadb.common.Connection;
 import com.faunadb.common.Connection.JvmDriver;
 import com.faunadb.client.types.Value.NullV;
 
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -456,7 +457,7 @@ public class FaunaClient {
           if (ex instanceof ConnectException || ex instanceof TimeoutException) {
               throw new UnavailableException(ex.getMessage(), ex);
           }
-          if (ex instanceof CompletionException && ex.getMessage().contains("too many concurrent streams")) {
+        if (ex instanceof CompletionException && ex.getCause() instanceof IOException && ex.getMessage().contains("too many concurrent streams")) {
             throw new BadRequestException("the maximum number of streams has been reached for this client");
           }
       });

--- a/faunadb-java/src/main/java/com/faunadb/client/errors/BadRequestException.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/errors/BadRequestException.java
@@ -9,4 +9,7 @@ public class BadRequestException extends FaunaException {
   public BadRequestException(HttpResponses.QueryErrorResponse response) {
     super(response);
   }
+  public BadRequestException(String message) {
+    super(message);
+  }
 }

--- a/faunadb-scala/src/load/scala/faunadb/FaunaClientFixture.scala
+++ b/faunadb-scala/src/load/scala/faunadb/FaunaClientFixture.scala
@@ -8,6 +8,8 @@ trait FaunaClientFixture extends SuiteMixin with BeforeAndAfterAll { self: Fixtu
   private var _rootClient: FaunaClient = _
   protected def rootClient = _rootClient
 
+  protected def config: collection.Map[String, String] = _config
+
   override protected def beforeAll(): Unit = {
     val config = {
       val rootKey = Option(System.getenv("FAUNA_ROOT_KEY")) getOrElse {
@@ -55,8 +57,7 @@ trait FaunaClientFixture extends SuiteMixin with BeforeAndAfterAll { self: Fixtu
 
     def createFaunaClient(secret: String): Future[FaunaClient] = Future.successful {
       // each test gets a new client to avoid interference such as triggering max_concurrent_streams error
-      val newClient = FaunaClient(endpoint = _config("root_url"), secret = _config("root_token"))
-      newClient.sessionClient(secret)
+      FaunaClient(endpoint = config("root_url"), secret = secret)
     }
 
     def deleteDatabase(): Future[Value] = rootClient.query(Delete(Database(databaseName)))

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -15,7 +15,7 @@ import java.net.http.HttpResponse
 import java.util.concurrent.{CompletionException, Flow, TimeoutException}
 
 import com.faunadb.common.http.ResponseBodyStringProcessor
-import faunadb.FaunaClient.{EventField, successEmptyIterator}
+import faunadb.FaunaClient.EventField
 import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
 
 import scala.collection.JavaConverters._
@@ -24,7 +24,6 @@ import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 /** Companion object to the FaunaClient class. */
 object FaunaClient {
@@ -60,9 +59,6 @@ object FaunaClient {
   case object PrevField extends EventField("prev")
   case object DiffField extends EventField("diff")
   case object ActionField extends EventField("action")
-
-  private val successEmptyIterator = Success(Iterator.empty)
-
 }
 
 /**
@@ -203,10 +199,8 @@ class FaunaClient private (connection: Connection) {
 
     response
       .flatMap {
-        case successResponse if successResponse.statusCode() < 300 =>
-          Future.fromTry(handleSuccessResponse(successResponse))
-        case errorResponse =>
-          Future.fromTry(handleErrorResponse(errorResponse.statusCode(), errorResponse.body()))
+        case successResponse if successResponse.statusCode() < 300 => handleSuccessResponse(successResponse)
+        case errorResponse => handleErrorResponse(errorResponse.statusCode(), errorResponse.body())
       }
       .recoverWith(handleNetworkExceptions)
   }
@@ -251,7 +245,7 @@ class FaunaClient private (connection: Connection) {
           // The request failed, we need to consume the body manually for error reporting
           ResponseBodyStringProcessor.consumeBody(errorResponse)
             .toScala
-            .flatMap(errorBody => Future.fromTry(handleErrorResponse(errorResponse.statusCode(), errorBody)))
+            .flatMap(errorBody => handleErrorResponse(errorResponse.statusCode(), errorBody))
       }
       .recoverWith(handleNetworkExceptions)
   }
@@ -298,24 +292,24 @@ class FaunaClient private (connection: Connection) {
   def syncLastTxnTime(timestamp: Long): Unit =
     connection.syncLastTxnTime(timestamp)
 
-  private def parseResponseBody(responseBody: String): Try[JsonNode] = {
-    def parse: Try[Option[JsonNode]] = Try(Option(json.readTree(responseBody)))
+  private def parseResponseBody(responseBody: String)(implicit ec: ExecutionContext): Future[JsonNode] = {
+    def parse: Future[Option[JsonNode]] = Future(Option(json.readTree(responseBody)))
 
     parse.flatMap {
-      case Some(json) => Success(json)
-      case None => Failure(new IOException("Invalid JSON."))
+      case Some(json) => Future.successful(json)
+      case None => Future.failed(new IOException("Invalid JSON."))
     }
   }
 
-  private def handleSuccessResponse(response: HttpResponse[String]): Try[Value] = {
-    def getResource(body: JsonNode): Try[JsonNode] = Option(body.get("resource")) match {
-      case Some(resource) => Success(resource)
-      case None => Failure(new IOException("Invalid JSON."))
+  private def handleSuccessResponse(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[Value] = {
+    def getResource(body: JsonNode): Future[JsonNode] = Option(body.get("resource")) match {
+      case Some(resource) => Future.successful(resource)
+      case None => Future.failed(new IOException("Invalid JSON."))
     }
 
-    def parseValue(resource: JsonNode): Try[Value] = resource match {
-      case _: NullNode => Success(NullV)
-      case _: JsonNode => Try(json.treeToValue[Value](resource, classOf[Value]))
+    def parseValue(resource: JsonNode): Future[Value] = resource match {
+      case _: NullNode => Future.successful(NullV)
+      case _: JsonNode => Future(json.treeToValue[Value](resource, classOf[Value]))
     }
 
     for {
@@ -325,18 +319,18 @@ class FaunaClient private (connection: Connection) {
     } yield value
   }
 
-  private def handleErrorResponse(statusCode: Int, responseBody: String)(implicit ec: ExecutionContext): Try[Nothing] = {
-    def parseErrors(): Try[QueryErrorResponse] = {
-      def getErrors(body: JsonNode): Try[Iterator[JsonNode]] = Option(body.get("errors")) match {
-        case Some(errors: ArrayNode) => Success(errors.iterator().asScala)
-        case _ => successEmptyIterator // promote as constant
+  private def handleErrorResponse(statusCode: Int, responseBody: String)(implicit ec: ExecutionContext): Future[Nothing] = {
+    def parseErrors(): Future[QueryErrorResponse] = {
+      def getErrors(body: JsonNode): Future[Iterator[JsonNode]] = Option(body.get("errors")) match {
+        case Some(errors: ArrayNode) => Future.successful(errors.iterator().asScala)
+        case _ => Future.successful(Iterator.empty)
       }
 
-      def parseErrors(errors: Iterator[JsonNode]): Try[IndexedSeq[QueryError]] = Try {
+      def parseErrors(errors: Iterator[JsonNode]): Future[IndexedSeq[QueryError]] = Future {
         errors.map(json.treeToValue(_, classOf[QueryError])).toIndexedSeq
       }
 
-      val result: Try[QueryErrorResponse] =
+      val result: Future[QueryErrorResponse] =
         for {
           body <- parseResponseBody(responseBody)
           errors <- getErrors(body)
@@ -345,16 +339,16 @@ class FaunaClient private (connection: Connection) {
 
       result
         .recoverWith {
-          case e: FaunaException => Failure(e)
-          case unavailable if statusCode == 503 => Failure(new UnavailableException("Service Unavailable: Unparseable response.", unavailable))
-          case unknown => Failure(new UnknownException(s"Unparseable service $unknown response.", unknown))
+          case e: FaunaException => Future.failed(e)
+          case unavailable if statusCode == 503 => Future.failed(new UnavailableException("Service Unavailable: Unparseable response.", unavailable))
+          case unknown => Future.failed(new UnknownException(s"Unparseable service $unknown response.", unknown))
         }
     }
 
-    def parseErrorsAndFailWith(fun: QueryErrorResponse => FaunaException): Try[Nothing] = {
+    def parseErrorsAndFailWith(fun: QueryErrorResponse => FaunaException): Future[Nothing] = {
       parseErrors().flatMap { errors =>
         val exception = fun(errors)
-        Failure(exception)
+        Future.failed(exception)
       }
     }
 
@@ -374,7 +368,7 @@ class FaunaClient private (connection: Connection) {
       Future.failed(new UnavailableException(ex.getMessage, ex))
     case ex: TimeoutException =>
       Future.failed(new TimeoutException(ex.getMessage))
-    case ex: CompletionException if ex.getMessage.contains("too many concurrent streams") =>
+    case ex: CompletionException if ex.getCause.isInstanceOf[IOException] && ex.getMessage.contains("too many concurrent streams") =>
       Future.failed(BadRequestException(None, "the maximum number of streams has been reached for this client"))
   }
 


### PR DESCRIPTION
The goal of this PR is to:
- test the current limitation regarding the max number of streams per connection
- offer a nicer exception to the user to handle this error case

Given a situation where 100 streams are already running on a connection and an additional call to `client.stream` is made, it will result in:
- a `BadRequestException("the maximum number of streams has been reached for this client")` exception returned to the caller of `client.stream`
- each 100 open streams will fail by receiving on their subscriber `onError` handler the exception `java.io.IOException: GOAWAY received`

The user experience is not great for the subscriber in that case but I am not sure catching all `IOException` for inspection is a better idea.

To get there I had to perform a couple of changes:
- each test case in `FaunaClientLoadSpec` gets a new client to avoid sharing connections
- catch and transform the `max_concurrent_streams` exception