### PR TITLE
Restore test cases evaluating Contains function

### DIFF
--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -1178,7 +1178,6 @@ public class ClientSpec {
     );
   }
 
-  @Ignore
   @Test
   public void shouldEvalContainsExpression() throws Exception {
     Value contains = query(

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -763,7 +763,7 @@ class ClientSpec
     notR.to[Boolean].get shouldBe true
   }
 
-  it should "test Contains function" ignore {
+  it should "test Contains function" in {
     val containsR = client.query(Contains("favorites" / "foods", Obj("favorites" -> Obj("foods" -> Arr("crunchings", "munchings"))))).futureValue
     containsR.to[Boolean].get shouldBe true
 


### PR DESCRIPTION
Restoring test cases evaluating `Contains` function since now the CI pipeline should be supporting them.