### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,12 @@
+4.0.0
+* Upgrade to Java 11
+* Upgrade project dependencies
+* Replace Netty HTTP Client with Java HTTP client
+* Change from Basic to Bearer authentication scheme
+* Add streaming API to the FaunaClient
+* Add Third-party Auth functions: CurrentIdentity(), HasCurrentIdentity(), CurrentToken(),
+  HasCurrentToken(), CreateAccessProvider(), AccessProvider(), AccessProviders()
+
 3.0.1
 * Upgrade to Scala 2.12.12
 * Upgrade to sbt 1.3.13

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This repository contains the FaunaDB drivers for the JVM languages. Currently, J
 
 Javadocs and Scaladocs are hosted on GitHub:
 
-* [faunadb-java](http://fauna.github.io/faunadb-jvm/3.0.1/faunadb-java/api/)
-* [faunadb-scala](http://fauna.github.io/faunadb-jvm/3.0.1/faunadb-scala/api/)
+* [faunadb-java](http://fauna.github.io/faunadb-jvm/4.0.0/faunadb-java/api/)
+* [faunadb-scala](http://fauna.github.io/faunadb-jvm/4.0.0/faunadb-scala/api/)
 
 Details Documentation for each language:
 
@@ -54,7 +54,7 @@ Download from the Maven central repository:
   <dependency>
     <groupId>com.faunadb</groupId>
     <artifactId>faunadb-java</artifactId>
-    <version>3.0.1</version>
+    <version>4.0.0</version>
     <scope>compile</scope>
   </dependency>
   ...
@@ -158,7 +158,7 @@ List<Value> events = capturedEvents.get();
 ##### faunadb-scala/sbt
 
 ```scala
-libraryDependencies += ("com.faunadb" %% "faunadb-scala" % "3.0.1")
+libraryDependencies += ("com.faunadb" %% "faunadb-scala" % "4.0.0")
 ```
 
 ##### Basic Usage

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ import scoverage.ScoverageSbtPlugin.autoImport._
 
 object Settings {
 
-  lazy val driverVersion = "4.0.0-SNAPSHOT"
+  lazy val driverVersion = "4.0.0"
 
   lazy val scala211 = "2.11.12"
   lazy val scala212 = "2.12.12"


### PR DESCRIPTION
#### Release 4.0.0

* Upgrade to Java 11
* Upgrade project dependencies
* Replace Netty HTTP Client with Java HTTP client
* Change from Basic to Bearer authentication scheme
* Add streaming API to the FaunaClient
* Add Third-party Auth functions: CurrentIdentity(), HasCurrentIdentity(), CurrentToken(),
  HasCurrentToken(), CreateAccessProvider(), AccessProvider(), AccessProviders()