### PR TITLE
chore: Updated faunadb docker image to use public one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
   core-nightly:
     executor:
       name: core
-      version: nightly
+      version: "nightly"
     steps:
       - build_and_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,8 @@ executors:
     resource_class: large
     docker:
       - image: openjdk:11
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise/<<parameters.version>>:latest
+      - image: fauna/faunadb
         name: core
-        auth:
-          username: _json_key
-          password: $GCR_KEY
     environment:
       SBT_VERSION: 1.3.13
       FAUNA_ROOT_KEY: secret

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ jobs:
   core-nightly:
     executor:
       name: core
-      version: "nightly"
     steps:
       - build_and_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ executors:
       - image: openjdk:11
       - image: fauna/faunadb
         name: core
-
     environment:
       SBT_VERSION: 1.3.13
       FAUNA_ROOT_KEY: secret

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@ description: FaunaDB JVM Driver Tests
 
 executors:
   core:
-    parameters:
-      version:
-        type: enum
-        enum: ["nightly"]
     resource_class: large
     docker:
       - image: openjdk:11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ executors:
       - image: openjdk:11
       - image: fauna/faunadb
         name: core
+
     environment:
       SBT_VERSION: 1.3.13
       FAUNA_ROOT_KEY: secret


### PR DESCRIPTION
Changed faunadb image for circleci to a public one from dockerhub, so we can run builds from fork repositories