### PR TITLE
DRV-522: always send query timeout header

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -37,8 +37,8 @@ import static java.lang.String.format;
 public class Connection {
 
   private static final String API_VERSION = "4";
-  private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
-  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60000;
+  private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(60);
   private static final String DEFAULT_USER_AGENT = "Fauna JVM Http Client";
   private static final URL FAUNA_ROOT;
 
@@ -208,11 +208,11 @@ public class Connection {
       http = Objects.requireNonNullElseGet(client, () ->
         // TODO: [DRV-169] allow users to override default executor
         HttpClient.newBuilder()
-          .connectTimeout(Duration.ofMillis(DEFAULT_CONNECTION_TIMEOUT_MS))
+          .connectTimeout(DEFAULT_CONNECTION_TIMEOUT)
           .build()
       );
 
-      String connectionUserAgent = userAgent.orElseGet(() -> DEFAULT_USER_AGENT);
+      String connectionUserAgent = userAgent.orElse(DEFAULT_USER_AGENT);
 
       return new Connection(root, authToken, http, registry, jvmDriver, lastSeenTxn, queryTimeout, connectionUserAgent);
     }
@@ -440,7 +440,8 @@ public class Connection {
 
     // If a query timeout has been given for the current request,
     // override the one from the Connection if any
-    Optional<Duration> queryTimeout = requestQueryTimeout.or(() -> defaultQueryTimeout);
+    // or use a default value
+    Duration queryTimeout = requestQueryTimeout.or(() -> defaultQueryTimeout).orElse(DEFAULT_REQUEST_TIMEOUT);
 
     Optional<Long> lastTxnTime = (getLastTxnTime() > 0) ? Optional.of(getLastTxnTime()) : Optional.empty();
 
@@ -448,17 +449,17 @@ public class Connection {
       HttpRequest.newBuilder()
         .uri(requestUri)
         .version(httpVersion)
-        .timeout(Duration.ofMillis(DEFAULT_REQUEST_TIMEOUT_MS))
+        .timeout(queryTimeout)
         .method(httpMethod, bodyPublisher)
         .headers(
           "Authorization", authHeader,
           X_FAUNADB_API_VERSION, API_VERSION,
           USER_AGENT, userAgent,
           X_FAUNA_DRIVER, jvmDriver.toString(),
+          X_QUERY_TIMEOUT, String.valueOf(queryTimeout.toMillis()),
           "Content-type", "application/json; charset=utf-8"
         );
 
-    queryTimeout.ifPresent(timeout -> requestBuilder.header(X_QUERY_TIMEOUT, String.valueOf(timeout.toMillis())));
     lastTxnTime.ifPresent(time -> requestBuilder.header(X_LAST_SEEN_TXN, Long.toString(time)));
 
     return requestBuilder.build();

--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -361,7 +361,7 @@ public class Connection {
     HttpRequest request;
     try {
       request = makeHttpRequest(httpMethod, path, body, params, requestQueryTimeout, HttpClient.Version.HTTP_1_1);
-    } catch (MalformedURLException | URISyntaxException | JsonProcessingException ex) {
+    } catch (IllegalArgumentException| MalformedURLException | URISyntaxException | JsonProcessingException ex) {
       rv.completeExceptionally(ex);
       return rv;
     }

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -230,8 +230,8 @@ public class ClientSpec {
 
   @Test
   public void shouldThrowATimeoutErrorWhenQueryTimeoutIsZero() throws Exception {
-    thrown.expectCause(isA(UnavailableException.class));
-    thrown.expectMessage(containsString("time out: Read timed out."));
+    thrown.expectCause(isA(IllegalArgumentException.class));
+    thrown.expectMessage(containsString("Invalid duration"));
     Duration timeout = Duration.ZERO;
     query(Value("echo"), timeout).get();
   }

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -151,10 +151,17 @@ class ClientSpec
   }
 
   it should "fail with timeout error" in {
+    val timeout = 1 nano // the jdk client does not accept Duration.Zero as timeout
+    val thrown = client.query("echo", timeout).failed.futureValue
+    thrown shouldBe an[java.util.concurrent.CompletionException]
+    thrown.getCause shouldBe an[java.net.http.HttpTimeoutException]
+  }
+
+  it should "fail if timeout is zero" in {
     val timeout = Duration.Zero
     val thrown = client.query("echo", timeout).failed.futureValue
-    thrown shouldBe an[UnavailableException]
-    thrown.getMessage should include ("time out: Read timed out.")
+    thrown shouldBe an[IllegalArgumentException]
+    thrown.getMessage should include ("Invalid duration")
   }
 
   it should "fail with permission denied" in {


### PR DESCRIPTION
This PR makes sure we are always sending the `X_QUERY_TIMEOUT` header.

I did a bit of cleanup to reduce allocations of `Duration` objects on the way.