### PR TITLE
DRV-551: Expose billing metrics #299c

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,42 @@ public class Main {
 }
 ```
 
+##### Per query metrics
+There are several metrics that returned per each request in response headers. Read this [doc](https://docs.fauna.com/fauna/current/concepts/billing.html#perquery) to have more info.
+You can access these metrics by:
+```java
+import com.faunadb.client.FaunaClient;
+
+import static com.faunadb.client.query.Language.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+
+        //Create an admin connection to FaunaDB.
+        FaunaClient adminClient =
+            FaunaClient.builder()
+                .withSecret("put-your-key-secret-here")
+                .build();
+
+        MetricsResponse metricsResponse = adminClient.queryWithMetrics(
+            Paginate(Match(Index("spells_by_element"), Value("fire"))),
+            null
+    	).get();
+
+        // the result of the query, as if you invoke 'adminClient.query' function instead
+        Value value = metricsResponse.getValue();
+
+        // gets the value of 'x-byte-read-ops' metric
+        Optional<String> byteReadOps = metricsResponse.getMetric(MetricsResponse.Metrics.BYTE_READ_OPS);
+        // gets the value of 'x-byte-write-ops' metric
+        Optional<String> byteWriteOps = metricsResponse.getMetric(MetricsResponse.Metrics.BYTE_WRITE_OPS);
+
+        // you can get other metrics in the same way,
+        // all of them are exposed via MetricsResponse.Metrics enum
+    }
+}
+```
+
 ##### Document Streaming
 
 Fauna supports document streaming, where changes to a streamed document are pushed to all clients subscribing to that document.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,44 @@ object Main extends App {
 }
 ```
 
+##### Per query metrics
+There are several metrics that returned per each request in response headers. Read this [doc](https://docs.fauna.com/fauna/current/concepts/billing.html#perquery) to have more info.
+You can access these metrics by:
+```scala
+import faunadb._
+import faunadb.query._
+import scala.concurrent._
+import scala.concurrent.duration._
+
+/**
+  * This example connects to FaunaDB Cloud using the secret provided
+  * and creates a new database named "my-first-database"
+  */
+object Main extends App {
+
+  import ExecutionContext.Implicits._
+
+  val client = FaunaClient(
+    secret = "put-your-secret-here"
+  )
+
+  val metricsResponse = client.queryWithMetrics(
+    Paginate(Match(Index("spells_by_element"), Value("fire"))),
+    None
+  ).futureValue
+
+  // the result of the query, as if you invoke 'client.query' function instead
+  val value = metricsResponse.value
+  
+  // gets the value of 'x-byte-read-ops' metric
+  val byteReadOps = metricsResponse.getMetric(Metrics.ByteReadOps)
+  // gets the value of 'x-byte-write-ops' metric
+  val byteWriteOps = metricsResponse.getMetric(Metrics.ByteWriteOps)
+
+  // you can get other metrics in the same way,
+  // all of them are exposed via Metrics enum}
+```
+
 ##### Document Streaming
 
 Fauna supports document streaming, where changes to a streamed document are pushed to all clients subscribing to that document.

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -352,9 +352,10 @@ public class FaunaClient {
   }
 
   private MetricsResponse handleResponseWithMetrics(HttpResponse<String> response) {
-    Map<MetricsResponse.Metrics, Optional<String>> metrics = MetricsResponse.Metrics.stream()
-        .collect(
-            Collectors.toMap(Function.identity(), m -> response.headers().firstValue(m.getMetric())));
+    Map<MetricsResponse.Metrics, String> metrics = new HashMap<>();
+    MetricsResponse.Metrics.vals().forEach(m ->
+        response.headers().firstValue(m.getMetric()).ifPresent(v -> metrics.put(m, v))
+    );
     Value value = handleResponse(response);
     return MetricsResponse.of(value, metrics);
   }

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -12,6 +12,7 @@ import com.faunadb.client.streaming.BodyValueFlowProcessor;
 import com.faunadb.client.streaming.EventField;
 import com.faunadb.client.streaming.SnapshotEventFlowProcessor;
 import com.faunadb.client.types.Field;
+import com.faunadb.client.types.MetricsResponse;
 import com.faunadb.client.types.Value;
 import com.faunadb.common.Connection;
 import com.faunadb.common.Connection.JvmDriver;
@@ -229,6 +230,26 @@ public class FaunaClient {
   }
 
   /**
+   * Issues a Query to FaunaDB with extra information
+   * <p>
+   * Queries are constructed by the helper methods in the {@link com.faunadb.client.query.Language} class.
+   * <p>
+   * Responses are represented as structured tree where each node is a {@link Value} instance.
+   * {@link Value} instances can be converted to native types. See {@link Value} class for details.
+   *
+   * @param expr the query to be executed.
+   * @param timeout the timeout for the current query. It replaces the timeout value set for this
+   *                {@link FaunaClient} (if any), for the scope of this query. The timeout value
+   *                has milliseconds precision.
+   * @return a {@link CompletableFuture} containing the root node of the response tree.
+   * @see MetricsResponse
+   * @see com.faunadb.client.query.Language
+   */
+  public CompletableFuture<MetricsResponse> queryWithMetrics(Expr expr, Optional<Duration> timeout) {
+    return performRequestWithMetrics(json.valueToTree(expr), timeout);
+  }
+
+  /**
    * Issues multiple queries to FaunaDB.
    * <p>
    * These queries are sent to FaunaDB in a single request. A list containing all responses is returned
@@ -310,7 +331,7 @@ public class FaunaClient {
     return connection.getLastTxnTime();
   }
 
-  private Value handleResponse(HttpResponse<String> response) {
+  private MetricsResponse handleResponse(HttpResponse<String> response, boolean withMetrics) {
     try {
       handleQueryErrors(response.statusCode(), response.body());
       JsonNode responseBody = parseResponseBody(response.body());
@@ -320,18 +341,38 @@ public class FaunaClient {
         throw new IllegalArgumentException("Invalid JSON.");
       }
 
-      if(resource instanceof NullNode) {
-        return NullV.NULL;
+      Map<MetricsResponse.Metrics, Optional<String>> metrics = Map.of();
+      if (withMetrics) {
+        metrics = MetricsResponse.Metrics.stream()
+                .collect(
+                        Collectors.toMap(Function.identity(), m -> response.headers().firstValue(m.getMetric())));
       }
 
-      return json.treeToValue(resource, Value.class);
+      if(resource instanceof NullNode) {
+        return MetricsResponse.of(NullV.NULL, metrics);
+      }
+
+      Value value = json.treeToValue(resource, Value.class);
+      return MetricsResponse.of(value, metrics);
     } catch (JsonProcessingException | IllegalArgumentException ex) {
       throw new AssertionError(ex);
     }
   }
 
+  private Value handleResponse(HttpResponse<String> response) {
+    return handleResponse(response, false).getValue();
+  }
+
+  private MetricsResponse handleResponseWithMetrics(HttpResponse<String> response) {
+    return handleResponse(response, true);
+  }
+
   private CompletableFuture<Value> performRequest(JsonNode body, Optional<Duration> queryTimeout) {
     return handleNetworkExceptions(connection.post("", body, queryTimeout).thenApply(this::handleResponse));
+  }
+
+  private CompletableFuture<MetricsResponse> performRequestWithMetrics(JsonNode body, Optional<Duration> queryTimeout) {
+    return handleNetworkExceptions(connection.post("", body, queryTimeout).thenApply(this::handleResponseWithMetrics));
   }
 
   /**

--- a/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
@@ -1,5 +1,7 @@
 package com.faunadb.client.types;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -10,15 +12,15 @@ import java.util.stream.Stream;
  * and can be retrieved by using {@link #getMetric(Metrics)} method
  */
 public class MetricsResponse {
-    private final Map<Metrics, Optional<String>> metricsMap;
+    private final Map<Metrics, String> metricsMap;
     private final Value value;
 
-    private MetricsResponse(Value value, Map<Metrics, Optional<String>> metricsMap) {
+    private MetricsResponse(Value value, Map<Metrics, String> metricsMap) {
         this.value = value;
         this.metricsMap = metricsMap;
     }
 
-    public static MetricsResponse of(Value value, Map<Metrics, Optional<String>> metricsMap) {
+    public static MetricsResponse of(Value value, Map<Metrics, String> metricsMap) {
         return new MetricsResponse(value, metricsMap);
     }
 
@@ -36,11 +38,7 @@ public class MetricsResponse {
      * @return the metric value
      */
     public Optional<String> getMetric(Metrics metric) {
-        if (metricsMap.containsKey(metric)) {
-            return metricsMap.get(metric);
-        }
-
-        return Optional.empty();
+        return Optional.ofNullable(metricsMap.get(metric));
     }
 
     /**
@@ -74,5 +72,7 @@ public class MetricsResponse {
         public static Stream<Metrics> stream() {
             return Stream.of(Metrics.values());
         }
+
+        public static List<Metrics> vals() { return Arrays.asList(Metrics.values()); }
     }
 }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
  * An aggregation type which consists of {@link Value} instance and extra information of response.
@@ -67,10 +66,6 @@ public class MetricsResponse {
 
         public String getMetric() {
             return metric;
-        }
-
-        public static Stream<Metrics> stream() {
-            return Stream.of(Metrics.values());
         }
 
         public static List<Metrics> vals() { return Arrays.asList(Metrics.values()); }

--- a/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
@@ -1,0 +1,78 @@
+package com.faunadb.client.types;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * An aggregation type which consists of {@link Value} instance and extra information of response.
+ * Extra information is stored in the metricsMap
+ * and can be retrieved by using {@link #getMetric(Metrics)} method
+ */
+public class MetricsResponse {
+    private final Map<Metrics, Optional<String>> metricsMap;
+    private final Value value;
+
+    private MetricsResponse(Value value, Map<Metrics, Optional<String>> metricsMap) {
+        this.value = value;
+        this.metricsMap = metricsMap;
+    }
+
+    public static MetricsResponse of(Value value, Map<Metrics, Optional<String>> metricsMap) {
+        return new MetricsResponse(value, metricsMap);
+    }
+
+    /**
+     * Gets the {@link Value} part
+     * @return the root node of the response tree
+     */
+    public Value getValue() {
+        return value;
+    }
+
+    /**
+     * Gets a specified metric
+     * @param metric a metric user wants to retrieve
+     * @return the metric value
+     */
+    public Optional<String> getMetric(Metrics metric) {
+        if (metricsMap.containsKey(metric)) {
+            return metricsMap.get(metric);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Different header names that indicate the resources used in any query to faunadb server
+     */
+    public enum Metrics {
+        BYTE_READ_OPS("x-byte-read-ops"),
+        BYTE_WRITE_OPS("x-byte-write-ops"),
+        COMPUTE_OPS("x-compute-ops"),
+        FAUNADB_BUILD("x-faunadb-build"),
+        QUERY_BYTES_IN("x-query-bytes-in"),
+        QUERY_BYTES_OUT("x-query-bytes-out"),
+        QUERY_TIME("x-query-time"),
+        READ_OPS("x-read-ops"),
+        STORAGE_BYTES_READ("x-storage-bytes-read"),
+        STORAGE_BYTES_WRITE("x-storage-bytes-write"),
+        TXN_RETRIES("x-txn-retries"),
+        TXN_TIME("x-txn-time"),
+        WRITE_OPS("x-write-ops");
+
+        private final String metric;
+
+        Metrics(String metric) {
+            this.metric = metric;
+        }
+
+        public String getMetric() {
+            return metric;
+        }
+
+        public static Stream<Metrics> stream() {
+            return Stream.of(Metrics.values());
+        }
+    }
+}

--- a/faunadb-java/src/test/java/com/faunadb/client/MetricsResponseSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/MetricsResponseSpec.java
@@ -1,0 +1,47 @@
+package com.faunadb.client;
+
+import com.faunadb.client.types.MetricsResponse;
+import com.faunadb.client.types.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetricsResponseSpec {
+
+    Map<MetricsResponse.Metrics, String> metricsMap;
+
+    @Before
+    public void setUp() {
+        metricsMap = Map.of(
+                MetricsResponse.Metrics.QUERY_BYTES_IN, "35",
+                MetricsResponse.Metrics.QUERY_BYTES_OUT, "75"
+        );
+    }
+
+    @Test
+    public void shouldReturnCorrectValueObject() {
+        Value value = new Value.LongV(25L);
+        MetricsResponse metricsResponse = MetricsResponse.of(value, metricsMap);
+
+        assertEquals(new Value.LongV(25L), metricsResponse.getValue());
+    }
+
+    @Test
+    public void shouldReturnEmptyIfMetricNotExists() {
+        MetricsResponse metricsResponse = MetricsResponse.of(null, metricsMap);
+
+        assertEquals(Optional.empty(), metricsResponse.getMetric(MetricsResponse.Metrics.BYTE_READ_OPS));
+    }
+
+    @Test
+    public void shouldReturnCorrectMetricValue() {
+        MetricsResponse metricsResponse = MetricsResponse.of(null, metricsMap);
+
+        assertEquals(Optional.of("35"), metricsResponse.getMetric(MetricsResponse.Metrics.QUERY_BYTES_IN));
+        assertEquals(Optional.of("75"), metricsResponse.getMetric(MetricsResponse.Metrics.QUERY_BYTES_OUT));
+    }
+}

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -18,7 +18,6 @@ import com.faunadb.common.http.ResponseBodyStringProcessor
 import faunadb.FaunaClient.EventField
 import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
 
-import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -219,7 +219,7 @@ class FaunaClient private (connection: Connection) {
 
     response
       .flatMap {
-        case successResponse if successResponse.statusCode() < 300 => handler(successResponse)
+        case successResponse if successResponse.statusCode() < 300 => handler.apply(successResponse)
         case errorResponse => handleErrorResponse(errorResponse.statusCode(), errorResponse.body())
       }
       .recoverWith(handleNetworkExceptions)

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -219,7 +219,7 @@ class FaunaClient private (connection: Connection) {
 
     response
       .flatMap {
-        case successResponse if successResponse.statusCode() < 300 => handler.apply(successResponse)
+        case successResponse if successResponse.statusCode() < 300 => handler(successResponse)
         case errorResponse => handleErrorResponse(errorResponse.statusCode(), errorResponse.body())
       }
       .recoverWith(handleNetworkExceptions)

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -18,6 +18,7 @@ import com.faunadb.common.http.ResponseBodyStringProcessor
 import faunadb.FaunaClient.EventField
 import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
 
+import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._
@@ -237,12 +238,9 @@ class FaunaClient private (connection: Connection) {
   }
 
   private def handleSuccessResponseWithMetrics(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
-    val metricsMap = Metrics.list map (item => item -> response.headers().firstValue(item)) toMap
-
-    for {
-      valueResponse <- handleSuccessResponse(response)
-      metricsResponse <- MetricsResponse(metricsMap, valueResponse)
-    } yield metricsResponse
+    val metricsMap = Metrics.All map (item => item -> response.headers().firstValue(item.toString).asScala) toMap
+    val metricsResponse: Future[MetricsResponse] = handleSuccessResponse(response).map(item => MetricsResponse(metricsMap, item))
+    metricsResponse
   }
 
   /**

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -234,13 +234,15 @@ class FaunaClient private (connection: Connection) {
   }
 
   private def handleSuccessResponseWithMetrics(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
-    val metrics = for {
-      item <- Metrics.All.iterator
-      header = response.headers().firstValue(item.toString).asScala
-      if header.isDefined
-    } yield item -> header.get
+    val metricsMap = Metrics.All
+      .iterator
+      .map(item => item -> response.headers().firstValue(item.toString).asScala)
+      .collect {
+        case (key, Some(value)) => key -> value
+      }
+      .toMap
 
-    handleSuccessResponse(response).map(item => MetricsResponse(metrics.toMap, item))
+    handleSuccessResponse(response).map(item => MetricsResponse(metricsMap, item))
   }
 
   /**

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -242,7 +242,7 @@ class FaunaClient private (connection: Connection) {
       }
       .toMap
 
-    handleSuccessResponse(response).map(item => MetricsResponse(metricsMap, item))
+    handleSuccessResponse(response).map(item => MetricsResponse(item, metricsMap))
   }
 
   /**

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -234,7 +234,11 @@ class FaunaClient private (connection: Connection) {
   }
 
   private def handleSuccessResponseWithMetrics(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
-    val metricsMap = (Metrics.All map (item => item -> response.headers().firstValue(item.toString).asScala)).toMap
+    val metricsMap = Metrics.All
+      .iterator
+      .filter(item => response.headers().firstValue(item.toString).isPresent)
+      .map(item => item -> response.headers().firstValue(item.toString).asScala.get)
+      .toMap
     handleSuccessResponse(response).map(item => MetricsResponse(metricsMap, item))
   }
 

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -8,12 +8,12 @@ import com.faunadb.common.Connection
 import com.faunadb.common.Connection.JvmDriver
 import faunadb.errors._
 import faunadb.query.{Expr, Get}
-import faunadb.values.{ArrayV, NullV, Value}
+import faunadb.values.{ArrayV, Metrics, MetricsResponse, NullV, Value}
+
 import java.io.IOException
 import java.net.ConnectException
 import java.net.http.HttpResponse
 import java.util.concurrent.{CompletionException, Flow, TimeoutException}
-
 import com.faunadb.common.http.ResponseBodyStringProcessor
 import faunadb.FaunaClient.EventField
 import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
@@ -146,6 +146,23 @@ class FaunaClient private (connection: Connection) {
     performRequest(json.valueToTree(expr), timeout)
 
   /**
+    * Issues a query.
+    *
+    * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+    * @param ec the `ExecutionContext` used to run the query asynchronously.
+    * @param timeout the timeout for the current query. It replaces the timeout value set for this
+    *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+    *                milliseconds precision.
+    * @return A [[scala.concurrent.Future]] containing the query result.
+    *         The result is an instance of [[faunadb.values.Result]],
+    *         which can be cast to a typed value using the
+    *         [[faunadb.values.Field]] API. If the query fails, failed
+    *         future is returned.
+    */
+  def queryWithMetrics(expr: Expr, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[MetricsResponse] =
+    performRequestWithMetrics(json.valueToTree(expr), timeout)
+
+  /**
     * Issues multiple queries as a single transaction.
     *
     * @param exprs the queries to run.
@@ -205,6 +222,27 @@ class FaunaClient private (connection: Connection) {
         case errorResponse => handleErrorResponse(errorResponse.statusCode(), errorResponse.body())
       }
       .recoverWith(handleNetworkExceptions)
+  }
+
+  private def performRequestWithMetrics(body: JsonNode, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
+    val javaTimeout = timeout.map(_.toJava).asJava
+    val response: Future[HttpResponse[String]] = connection.post("", body, javaTimeout).toScala
+
+    response
+      .flatMap {
+        case successResponse if successResponse.statusCode() < 300 => handleSuccessResponseWithMetrics(successResponse)
+        case errorResponse => handleErrorResponse(errorResponse.statusCode(), errorResponse.body())
+      }
+      .recoverWith(handleNetworkExceptions)
+  }
+
+  private def handleSuccessResponseWithMetrics(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
+    val metricsMap = Metrics.list map (item => item -> response.headers().firstValue(item)) toMap
+
+    for {
+      valueResponse <- handleSuccessResponse(response)
+      metricsResponse <- MetricsResponse(metricsMap, valueResponse)
+    } yield metricsResponse
   }
 
   /**

--- a/faunadb-scala/src/main/scala/faunadb/values/Metrics.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/Metrics.scala
@@ -1,0 +1,21 @@
+package faunadb.values
+
+object Metrics extends Enumeration {
+  type Metrics = Value
+
+  val ByteReadOps = Value("x-byte-read-ops")
+  val ByteWriteOps = Value("x-byte-write-ops")
+  val ComputeOps = Value("x-compute-ops")
+  val FaunaDbBuild = Value("x-faunadb-build")
+  val QueryBytesIn = Value("x-query-bytes-in")
+  val QueryBytesOut = Value("x-query-bytes-out")
+  val QueryTime = Value("x-query-time")
+  val ReadOps = Value("x-read-ops")
+  val StorageBytesRead = Value("x-storage-bytes-read")
+  val StorageBytesWrite = Value("x-storage-bytes-write")
+  val TxnRetries = Value("x-txn-retries")
+  val TxnTime = Value("x-txn-time")
+  val WriteOps = Value("x-write-ops")
+
+  val All = values.toList
+}

--- a/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
@@ -1,0 +1,30 @@
+package faunadb.values
+
+case class MetricsResponse(metricsMap: Map[String, Option[String]], value: Value) {
+
+  def getMetric(metric: String): Option[String] = {
+    metricsMap.getOrElse(metric, None)
+  }
+}
+
+object Metrics {
+  val BYTE_READ_OPS = "x-byte-read-ops"
+  val BYTE_WRITE_OPS = "x-byte-write-ops"
+  val COMPUTE_OPS = "x-compute-ops"
+  val FAUNADB_BUILD = "x-faunadb-build"
+  val QUERY_BYTES_IN = "x-query-bytes-in"
+  val QUERY_BYTES_OUT = "x-query-bytes-out"
+  val QUERY_TIME = "x-query-time"
+  val READ_OPS = "x-read-ops"
+  val STORAGE_BYTES_READ = "x-storage-bytes-read"
+  val STORAGE_BYTES_WRITE = "x-storage-bytes-write"
+  val TXN_RETRIES = "x-txn-retries"
+  val TXN_TIME = "x-txn-time"
+  val WRITE_OPS = "x-write-ops"
+
+  val list = List(
+    BYTE_READ_OPS, BYTE_WRITE_OPS, COMPUTE_OPS, FAUNADB_BUILD, QUERY_BYTES_IN,
+    QUERY_BYTES_OUT, QUERY_TIME, READ_OPS, STORAGE_BYTES_READ, STORAGE_BYTES_WRITE,
+    TXN_RETRIES, TXN_TIME, WRITE_OPS
+  )
+}

--- a/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
@@ -2,9 +2,9 @@ package faunadb.values
 
 import faunadb.values.Metrics.Metrics
 
-case class MetricsResponse(metricsMap: Map[Metrics, Option[String]], value: Value) {
+case class MetricsResponse(metricsMap: Map[Metrics, String], value: Value) {
 
   def getMetric(metric: Metrics): Option[String] = {
-    metricsMap.getOrElse(metric, None)
+    metricsMap.get(metric)
   }
 }

--- a/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
@@ -1,30 +1,10 @@
 package faunadb.values
 
-case class MetricsResponse(metricsMap: Map[String, Option[String]], value: Value) {
+import faunadb.values.Metrics.Metrics
 
-  def getMetric(metric: String): Option[String] = {
+case class MetricsResponse(metricsMap: Map[Metrics, Option[String]], value: Value) {
+
+  def getMetric(metric: Metrics): Option[String] = {
     metricsMap.getOrElse(metric, None)
   }
-}
-
-object Metrics {
-  val BYTE_READ_OPS = "x-byte-read-ops"
-  val BYTE_WRITE_OPS = "x-byte-write-ops"
-  val COMPUTE_OPS = "x-compute-ops"
-  val FAUNADB_BUILD = "x-faunadb-build"
-  val QUERY_BYTES_IN = "x-query-bytes-in"
-  val QUERY_BYTES_OUT = "x-query-bytes-out"
-  val QUERY_TIME = "x-query-time"
-  val READ_OPS = "x-read-ops"
-  val STORAGE_BYTES_READ = "x-storage-bytes-read"
-  val STORAGE_BYTES_WRITE = "x-storage-bytes-write"
-  val TXN_RETRIES = "x-txn-retries"
-  val TXN_TIME = "x-txn-time"
-  val WRITE_OPS = "x-write-ops"
-
-  val list = List(
-    BYTE_READ_OPS, BYTE_WRITE_OPS, COMPUTE_OPS, FAUNADB_BUILD, QUERY_BYTES_IN,
-    QUERY_BYTES_OUT, QUERY_TIME, READ_OPS, STORAGE_BYTES_READ, STORAGE_BYTES_WRITE,
-    TXN_RETRIES, TXN_TIME, WRITE_OPS
-  )
 }

--- a/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/MetricsResponse.scala
@@ -2,7 +2,7 @@ package faunadb.values
 
 import faunadb.values.Metrics.Metrics
 
-case class MetricsResponse(metricsMap: Map[Metrics, String], value: Value) {
+case class MetricsResponse(value: Value, metricsMap: Map[Metrics, String]) {
 
   def getMetric(metric: Metrics): Option[String] = {
     metricsMap.get(metric)

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -192,7 +192,7 @@ class ClientSpec
   }
 
   it should "receive a Null value properly for query with metrics" in {
-    client.queryWithMetrics(NullV, None).futureValue shouldBe NullV
+    client.queryWithMetrics(NullV, None).futureValue.value shouldBe NullV
   }
 
   it should "create a new instance" in {

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -127,6 +127,10 @@ class ClientSpec
     client.query(Get(RefV("1234", RefV("spells", Native.Collections)))).failed.futureValue shouldBe a[NotFoundException]
   }
 
+  "Fauna Client" should "should not find an instance for query with metrics" in {
+    client.queryWithMetrics(Get(RefV("1234", RefV("spells", Native.Collections))), None).failed.futureValue shouldBe a[NotFoundException]
+  }
+
   it should "abort the execution" in {
     client.query(Abort("a message")).failed.futureValue shouldBe a[BadRequestException]
   }
@@ -164,6 +168,13 @@ class ClientSpec
     thrown.getMessage should include ("Invalid duration")
   }
 
+  it should "fail if timeout is zero for query with metrics" in {
+    val timeout = Duration.Zero
+    val thrown = client.queryWithMetrics("echo", Some(timeout)).failed.futureValue
+    thrown shouldBe an[IllegalArgumentException]
+    thrown.getMessage should include ("Invalid duration")
+  }
+
   it should "fail with permission denied" in {
     val key = rootClient.query(CreateKey(Obj("database" -> Database(testDbName), "role" -> "client"))).futureValue
     val client = FaunaClient(endpoint = config("root_url"), secret = key(SecretField).get)
@@ -178,6 +189,10 @@ class ClientSpec
 
   it should "receive a Null value properly" in {
     client.query(NullV).futureValue shouldBe NullV
+  }
+
+  it should "receive a Null value properly for query with metrics" in {
+    client.queryWithMetrics(NullV, None).futureValue shouldBe NullV
   }
 
   it should "create a new instance" in {
@@ -289,6 +304,58 @@ class ClientSpec
     resp2("data").to[Seq[Value]].get.size shouldBe 1
     resp2("after").isDefined should equal (true)
     resp2("before").isDefined should equal (true)
+  }
+
+  //todo finish test
+//  it should "return single instance from index for query metrics" in {
+//    val res1 = client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "Magic Missile", "element" -> "arcane", "cost" -> 10L)))).futureValue
+//    val res2 = client.query(Create(Collection("spells"), Obj("data" -> Obj("name" -> "Fire bolt", "element" -> "fire", "cost" -> 15L)))).futureValue
+//
+//    val valueResponse = client.queryWithMetrics(
+//      Paginate(Match(Index("spells_by_element"), "fire")),
+//      None
+//    ).futureValue.value
+//
+//    valueResponse("data", "name").to[String].get shouldBe "Fire Bolt"
+//    valueResponse("data", "element").to[String].get shouldBe "arcane"
+//    valueResponse("data", "cost").to[Long].get shouldBe 15L
+//
+//    valueResponse shouldBe ""
+//  }
+
+  it should "return metrics data" in {
+    val metricsResponse = client.queryWithMetrics(
+      Paginate(Match(Index("spells_by_element"), Value("fire"))),
+      None
+    ).futureValue
+
+    val byteReadOps = metricsResponse.getMetric(Metrics.ByteReadOps)
+    val byteWriteOps = metricsResponse.getMetric(Metrics.ByteWriteOps)
+    val computeOps = metricsResponse.getMetric(Metrics.ComputeOps)
+    val faunaDbBuild = metricsResponse.getMetric(Metrics.FaunaDbBuild)
+    val queryBytesIn = metricsResponse.getMetric(Metrics.QueryBytesIn)
+    val queryBytesOut = metricsResponse.getMetric(Metrics.QueryBytesOut)
+    val queryTime = metricsResponse.getMetric(Metrics.QueryTime)
+    val readOps = metricsResponse.getMetric(Metrics.ReadOps)
+    val storageBytesRead = metricsResponse.getMetric(Metrics.StorageBytesRead)
+    val storageBytesWrite = metricsResponse.getMetric(Metrics.StorageBytesWrite)
+    val txnRetries = metricsResponse.getMetric(Metrics.TxnRetries)
+    val txnTime = metricsResponse.getMetric(Metrics.TxnTime)
+    val writeOps = metricsResponse.getMetric(Metrics.WriteOps)
+
+    byteReadOps.isDefined should equal (true)
+    byteWriteOps.isDefined should equal (true)
+    computeOps.isDefined should equal (true)
+    faunaDbBuild.isDefined should equal (true)
+    queryBytesIn.isDefined should equal (true)
+    queryBytesOut.isDefined should equal (true)
+    queryTime.isDefined should equal (true)
+    readOps.isDefined should equal (true)
+    storageBytesRead.isDefined should equal (true)
+    storageBytesWrite.isDefined should equal (true)
+    txnRetries.isDefined should equal (true)
+    txnTime.isDefined should equal (true)
+    writeOps.isDefined should equal (true)
   }
 
   it should "paginate with cursor object" in {

--- a/faunadb-scala/src/test/scala/faunadb/MetricsResponseSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/MetricsResponseSpec.scala
@@ -1,0 +1,35 @@
+package faunadb
+
+import faunadb.values.Metrics.Metrics
+import faunadb.values.{LongV, Metrics, MetricsResponse}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MetricsResponseSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  val metricsMap: Map[Metrics, String] = Map(
+    Metrics.QueryBytesIn -> "35",
+    Metrics.QueryBytesOut -> "75"
+  )
+
+  it should "return correct value object" in {
+    val value = LongV(25L)
+    val metricsResponse = MetricsResponse(value, metricsMap)
+
+    metricsResponse.value shouldBe LongV(25L)
+  }
+
+  it should "return empty if metric not exists" in {
+    val metricsResponse = MetricsResponse(null, metricsMap)
+
+    metricsResponse.getMetric(Metrics.ByteReadOps) shouldBe None
+  }
+
+  it should "return correct metric value" in {
+    val metricsResponse = MetricsResponse(null, metricsMap)
+
+    metricsResponse.getMetric(Metrics.QueryBytesIn) shouldBe Some("35")
+    metricsResponse.getMetric(Metrics.QueryBytesOut) shouldBe Some("75")
+  }
+}


### PR DESCRIPTION
### Notes
Responses from Fauna include all sorts of extra headers:

'x-byte-read-ops': '34',
'x-byte-write-ops': '0',
'x-compute-ops': '2',
'x-faunadb-build': '20.11.00.rc8-01f9c94',
'x-query-bytes-in': '120',
'x-query-bytes-out': '4459',
'x-query-time': '7',
'x-read-ops': '27',
'x-storage-bytes-read': '3047',
'x-storage-bytes-write': '0',
'x-txn-retries': '0',
'x-txn-time': '1605653866258457',
'x-write-ops': '0'

This PR introduces an additional 'queryWithMetrics' method that can provide all those metrics values alongside with query response.

### Jira ticket
https://faunadb.atlassian.net/browse/DRV-551