### PR TITLE
fix broken user-agent propagation

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -137,6 +137,17 @@ public class FaunaClient {
     }
 
     /**
+     * Sets the User-Agent header for all the Queries issued by this client.
+     *
+     * @param userAgent the userAgent value
+     * @return this {@link Builder} object
+     */
+    public Builder withUserAgent(String userAgent) {
+      this.userAgent = userAgent;
+      return this;
+    }
+
+    /**
      * Returns a newly constructed {@link FaunaClient} with configuration based on the settings of this {@link Builder}.
      * @return {@link FaunaClient}
      */

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -53,6 +53,7 @@ object FaunaClient {
     if (queryTimeout ne null) b.withQueryTimeout(queryTimeout.toJava)
     b.withJvmDriver(JvmDriver.SCALA)
     b.withScalaVersion(util.Properties.versionNumberString)
+    b.withUserAgent(userAgent)
 
     new FaunaClient(b.build)
   }


### PR DESCRIPTION
This PR is a quick fix for an incomplete implementation of https://github.com/fauna/faunadb-jvm/pull/295

The missing parts are:
- in the Java client, the `Builder` does not enable the user to set `userAgent`.
- in the Scala client, the `Builder` does not propagate the `userAgent` to the `Connection`.