### PR TITLE
OSS-770: handle 'HTTP/1.1 header parser received no bytes'

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -498,14 +498,17 @@ public class FaunaClient {
   }
 
   private <V> CompletableFuture<V> handleNetworkExceptions(CompletableFuture<V> f) {
-      return f.whenComplete((v, ex) -> {
-          if (ex instanceof ConnectException || ex instanceof TimeoutException) {
-              throw new UnavailableException(ex.getMessage(), ex);
-          }
-        if (ex instanceof CompletionException && ex.getCause() instanceof IOException && ex.getMessage().contains("too many concurrent streams")) {
-            throw new BadRequestException("the maximum number of streams has been reached for this client");
-          }
-      });
+    return f.whenComplete((v, ex) -> {
+      if (ex instanceof ConnectException || ex instanceof TimeoutException) {
+        throw new UnavailableException(ex.getMessage(), ex);
+      }
+      if (ex instanceof CompletionException && ex.getCause() instanceof IOException && ex.getMessage().contains("header parser received no bytes")) {
+        throw new UnavailableException(ex.getMessage(), ex);
+      }
+      if (ex instanceof CompletionException && ex.getCause() instanceof IOException && ex.getMessage().contains("too many concurrent streams")) {
+        throw new BadRequestException("the maximum number of streams has been reached for this client");
+      }
+    });
   }
 
   private JsonNode parseResponseBody(String responseBody) throws JsonProcessingException, IllegalArgumentException {

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -406,7 +406,9 @@ class FaunaClient private (connection: Connection) {
     case ex: ConnectException =>
       Future.failed(new UnavailableException(ex.getMessage, ex))
     case ex: TimeoutException =>
-      Future.failed(new TimeoutException(ex.getMessage))
+      Future.failed(new UnavailableException(ex.getMessage, ex))
+    case ex: CompletionException if ex.getCause.isInstanceOf[IOException] && ex.getMessage.contains("header parser received no bytes") =>
+      Future.failed(new UnavailableException(ex.getMessage, ex))
     case ex: CompletionException if ex.getCause.isInstanceOf[IOException] && ex.getMessage.contains("too many concurrent streams") =>
       Future.failed(BadRequestException(None, "the maximum number of streams has been reached for this client"))
   }


### PR DESCRIPTION
The driver throws the following error from time to time.

```
java.util.concurrent.CompletionException: java.io.IOException: HTTP/1.1 header parser received no bytes
	at java.base/java.util.concurrent.CompletableFuture.encodeRelay(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.completeRelay(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1Response.onReadError(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1Response$HeadersReader.onReadError(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1AsyncReceiver.checkForErrors(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1AsyncReceiver.flush(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SynchronizedRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$DelegatingExecutor.execute(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1AsyncReceiver.onReadError(Unknown Source)
	at java.net.http/jdk.internal.net.http.Http1AsyncReceiver$Http1TubeSubscriber.onComplete(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SSLTube$DelegateWrapper.onComplete(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SSLTube$SSLSubscriberWrapper.complete(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SSLTube$SSLSubscriberWrapper.onComplete(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SubscriberWrapper.checkCompletion(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SubscriberWrapper$DownstreamPusher.run1(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SubscriberWrapper$DownstreamPusher.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SynchronizedRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SubscriberWrapper.outgoing(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SSLFlowDelegate$Reader.processData(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SSLFlowDelegate$Reader$ReaderDownstreamPusher.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SynchronizedRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(Unknown Source)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
```

This PR make sure this exception does not bubble up to the user by turning it into a `UnavailableException` for both Java and Scala client.

I took the opportunity to align the drivers regarding the behavior for  `TimeoutException` by following the Java client.
