### PR TITLE
OSS-768: do not fail to deserialize unknown field - not strict

### DIFF
--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,7 +1,7 @@
 package faunadb
 
 import com.codahale.metrics.MetricRegistry
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode, ObjectMapper}
 import com.fasterxml.jackson.databind.node.{ArrayNode, NullNode}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.faunadb.common.Connection
@@ -99,6 +99,7 @@ object FaunaClient {
 class FaunaClient private (connection: Connection) {
 
   private[this] val json = new ObjectMapper
+  json.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   json.registerModule(new DefaultScalaModule)
 
   /**


### PR DESCRIPTION
The error response can contain a `ref` field in case of 409 which points to document that was contended on.
However the parsing of `QueryError` is strict and fails on unknown fields.

```
faunadb.errors.UnknownException: Unparseable service com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "ref" (class faunadb.QueryError), not marked as ignorable (5 known properties: "position", "description", "code", "failures", "cause"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: faunadb.QueryError["ref"]) response.
	at faunadb.FaunaClient$$anonfun$parseErrors$1$1.applyOrElse(FaunaClient.scala:383)
	at faunadb.FaunaClient$$anonfun$parseErrors$1$1.applyOrElse(FaunaClient.scala:380)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "ref" (class faunadb.QueryError), not marked as ignorable (5 known properties: "position", "description", "code", "failures", "cause"])
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: faunadb.QueryError["ref"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:987)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1974)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1686)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperties(BeanDeserializerBase.java:1635)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:541)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1390)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4569)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2798)
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:3261)
	at faunadb.FaunaClient.$anonfun$handleErrorResponse$2(FaunaClient.scala:369)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:461)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:62)
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:53)
	at scala.collection.immutable.VectorBuilder.$plus$plus$eq(Vector.scala:668)
	at scala.collection.immutable.VectorBuilder.$plus$plus$eq(Vector.scala:645)
	at scala.collection.TraversableOnce.to(TraversableOnce.scala:366)
	at scala.collection.TraversableOnce.to$(TraversableOnce.scala:364)
	at scala.collection.AbstractIterator.to(Iterator.scala:1431)
	at scala.collection.TraversableOnce.toIndexedSeq(TraversableOnce.scala:356)
	at scala.collection.TraversableOnce.toIndexedSeq$(TraversableOnce.scala:356)
	at scala.collection.AbstractIterator.toIndexedSeq(Iterator.scala:1431)
	at faunadb.FaunaClient.$anonfun$handleErrorResponse$1(FaunaClient.scala:369)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
```

This PR makes sure the JSON parser is not so strict and ignores unknown fields.

There is no need to modify the Java client because the `Deserializer` is hand written there.