### PR TITLE
OSS-786: dedicated error for 409

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -480,6 +480,8 @@ public class FaunaClient {
             throw new PermissionDeniedException(errorResponse);
           case 404:
             throw new NotFoundException(errorResponse);
+          case 409:
+            throw new TransactionContentionException(errorResponse);
           case 500:
             throw new InternalException(errorResponse);
           case 503:

--- a/faunadb-java/src/main/java/com/faunadb/client/errors/TransactionContentionException.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/errors/TransactionContentionException.java
@@ -1,0 +1,16 @@
+package com.faunadb.client.errors;
+
+import com.faunadb.client.HttpResponses;
+
+/**
+ * An exception thrown if a HTTP 409 is returned from FaunaDB.
+ */
+public class TransactionContentionException extends FaunaException {
+    public TransactionContentionException(HttpResponses.QueryErrorResponse response) {
+        super(response);
+    }
+
+    public TransactionContentionException(String message) {
+        super(message);
+    }
+}

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -397,6 +397,7 @@ class FaunaClient private (connection: Connection) {
       case 401 => parseErrorsAndFailWith(new UnauthorizedException(_))
       case 403 => parseErrorsAndFailWith(new PermissionDeniedException(_))
       case 404 => parseErrorsAndFailWith(new NotFoundException(_))
+      case 409 => parseErrorsAndFailWith(new TransactionContentionException(_))
       case 500 => parseErrorsAndFailWith(new InternalException(_))
       case 503 => parseErrorsAndFailWith(new UnavailableException(_))
       case _   => parseErrorsAndFailWith(new UnknownException(_))

--- a/faunadb-scala/src/main/scala/faunadb/errors/FaunaException.scala
+++ b/faunadb-scala/src/main/scala/faunadb/errors/FaunaException.scala
@@ -66,6 +66,14 @@ case class PermissionDeniedException(response: Option[QueryErrorResponse], messa
   def this(response: QueryErrorResponse) = this(Some(response), FaunaException.respToError(response.errors))
 }
 
+/**
+  * An exception thrown if FaunaDB responds with an HTTP 409.
+  */
+case class TransactionContentionException(response: Option[QueryErrorResponse], message: String) extends FaunaException(response, message) {
+  def this(message: String) = this(None, message)
+  def this(response: QueryErrorResponse) = this(Some(response), FaunaException.respToError(response.errors))
+}
+
 case class UnknownException(response: Option[QueryErrorResponse], message: String, cause: Throwable) extends FaunaException(response, message, cause) {
   def this(message: String, cause: Throwable) = this(None, message, cause)
   def this(response: QueryErrorResponse) = this(Some(response), FaunaException.respToError(response.errors), null)


### PR DESCRIPTION
This PR introduces a dedicated error type for 409 errors returned by the API.

Currently an `UnknownException` is returned which is making things more complicated than necessary to handle the 409s.

This new error type can be handled separately and keep `UnknownException` for things that are actually uncommon. 