### PR TITLE
OSS-962: share one Jackson's ObjectMapper for all client (perf)

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -190,7 +190,7 @@ public class FaunaClient {
     }
   }
 
-  private final ObjectMapper json = new ObjectMapper().registerModule(new Jdk8Module());
+  private static final ObjectMapper json = new ObjectMapper().registerModule(new Jdk8Module());
   private final Connection connection;
 
   private FaunaClient(Connection connection) {

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -9,6 +9,7 @@ import com.faunadb.common.Connection.JvmDriver
 import faunadb.errors._
 import faunadb.query.{Expr, Get}
 import faunadb.values.{ArrayV, Metrics, MetricsResponse, NullV, Value}
+import faunadb.FaunaClient.json
 import java.io.IOException
 import java.net.ConnectException
 import java.net.http.HttpResponse
@@ -28,6 +29,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /** Companion object to the FaunaClient class. */
 object FaunaClient {
+
+  // singleton ObjectMapper for all clients
+  private[faunadb] val json = new ObjectMapper
+  json.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  json.registerModule(new DefaultScalaModule)
 
   /**
     * Creates a new FaunaDB client.
@@ -102,10 +108,6 @@ object FaunaClient {
   * @constructor create a new client with a configured [[com.faunadb.common.Connection]].
   */
 class FaunaClient private (connection: Connection) {
-
-  private[this] val json = new ObjectMapper
-  json.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-  json.registerModule(new DefaultScalaModule)
 
   /**
     * Issues a query.


### PR DESCRIPTION
Applications creating several clients are spending a significant amount of time recreating a Jackson `ObjectMapper`.

This PR proposes to share one instance for all clients.

An `ObjectMapper` is supposed to be thread-safe.