### PR TITLE
Change docker image for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ executors:
       - image: openjdk:11
       - image: fauna/faunadb
         name: core
-        auth:
-          username: _json_key
-          password: $GCR_KEY
     environment:
       SBT_VERSION: 1.4.7
       FAUNA_ROOT_KEY: secret

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     resource_class: large
     docker:
       - image: openjdk:11
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise/<<parameters.version>>:latest
+      - image: fauna/faunadb
         name: core
         auth:
           username: _json_key


### PR DESCRIPTION
Set streaming is incompatible with the previous version of faunadb. 
Tests need to use the most recent version.