### PR TITLE
Revert "OSS-895 [java] Driver needs to detect and throw an error upon loss of networking (#323)"

### DIFF
--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -457,8 +457,7 @@ public class FaunaClient {
           .thenCompose(response -> {
             CompletableFuture<Flow.Publisher<Value>> publisher = new CompletableFuture<>();
             if (response.statusCode() < 300) {
-              BodyValueFlowProcessor bodyValueFlowProcessor = new BodyValueFlowProcessor(json, connection,
-                              () -> connection.performStreamRequest("POST", "stream", body, params));
+              BodyValueFlowProcessor bodyValueFlowProcessor = new BodyValueFlowProcessor(json, connection);
               response.body().subscribe(bodyValueFlowProcessor);
               publisher.complete(bodyValueFlowProcessor);
             } else {

--- a/faunadb-java/src/main/java/com/faunadb/client/streaming/BodyValueFlowProcessor.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/streaming/BodyValueFlowProcessor.java
@@ -10,29 +10,18 @@ import com.faunadb.common.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.concurrent.SubmissionPublisher;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class BodyValueFlowProcessor extends SubmissionPublisher<Value> implements Flow.Processor<java.util.List<ByteBuffer>, Value> {
 
     public BodyValueFlowProcessor(ObjectMapper json, Connection connection) {
         this.json = json;
         this.connection = connection;
-    }
-
-    public BodyValueFlowProcessor(ObjectMapper json, Connection connection, Supplier<CompletableFuture<HttpResponse<Flow.Publisher<List<ByteBuffer>>>>> connectionWatcher) {
-        this(json, connection);
-        connectionWatcherStart(connectionWatcher);
     }
 
     private static Value ErrorValue = new Value.StringV("error");
@@ -43,7 +32,6 @@ public class BodyValueFlowProcessor extends SubmissionPublisher<Value> implement
     private Connection connection;
     private Flow.Subscription subscription = null;
     private Flow.Subscriber<? super Value> subscriber = null;
-    private CompletableFuture<Optional<Exception>> connectionWatcherFuture;
 
     private void requestOne() {
         subscription.request(1);
@@ -108,31 +96,5 @@ public class BodyValueFlowProcessor extends SubmissionPublisher<Value> implement
     public void onComplete() {
         log.debug("subscription completed");
         subscriber.onComplete();
-
-        if (connectionWatcherFuture != null) {
-            connectionWatcherFuture.cancel(true);
-        }
-    }
-
-    private void connectionWatcherStart(Supplier<CompletableFuture<HttpResponse<Flow.Publisher<List<ByteBuffer>>>>> connectionWatcher) {
-        connectionWatcherFuture = CompletableFuture.supplyAsync(() -> {
-                while (true) {
-                    if(Thread.interrupted()) {
-                        break;
-                    }
-                    try {
-                        connectionWatcher.get().whenCompleteAsync((response, throwable) -> {
-                            if (throwable != null) {
-                                onError(throwable);
-                            }
-                        });
-                        SECONDS.sleep(10);
-                    } catch (Exception ex) {
-                        onError(ex);
-                    }
-                }
-                return Optional.empty();
-            }
-        );
     }
 }

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -284,7 +284,7 @@ class FaunaClient private (connection: Connection) {
       .flatMap {
         case successResponse if successResponse.statusCode() < 300 =>
           // Subscribe a new FlowEventValueProcessor to consume the Body's Flow.Publisher
-          val flowEventValueProcessor = new BodyValueFlowProcessor(json, txn => syncLastTxnTime(txn), () => connection.performStreamRequest("POST", "stream", body, params))
+          val flowEventValueProcessor = new BodyValueFlowProcessor(json, txn => syncLastTxnTime(txn))
           successResponse.body().subscribe(flowEventValueProcessor)
           Future.successful(flowEventValueProcessor)
         case errorResponse =>

--- a/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
+++ b/faunadb-scala/src/main/scala/faunadb/streaming/BodyValueFlowProcessor.scala
@@ -2,22 +2,18 @@ package faunadb.streaming
 
 import java.nio.ByteBuffer
 import java.util
-import java.util.concurrent.{CompletableFuture, Flow, SubmissionPublisher}
+import java.util.concurrent.{Flow, SubmissionPublisher}
+
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import faunadb.QueryError
-import faunadb.errors.{StreamingException, UnavailableException, UnknownException}
+import faunadb.errors.{StreamingException, UnknownException}
 import faunadb.values.{StringV, VSuccess, Value}
 import org.slf4j.LoggerFactory
 
-import java.net.http.HttpResponse
 import scala.collection.JavaConverters.asScalaIteratorConverter
-import scala.compat.java8.FutureConverters.CompletionStageOps
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
-private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTime: Long => Unit,
-                                               connectionWatcher:() => CompletableFuture[HttpResponse[Flow.Publisher[java.util.List[ByteBuffer]]]] ) extends SubmissionPublisher[Value] with Flow.Processor[util.List[ByteBuffer], Value] {
+private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTime: Long => Unit) extends SubmissionPublisher[Value] with Flow.Processor[util.List[ByteBuffer], Value] {
   private val log = LoggerFactory.getLogger(getClass)
   private var subscription: Flow.Subscription = _
   private var subscriber: Flow.Subscriber[_ >: Value] = _
@@ -25,8 +21,6 @@ private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTi
   // We do not request data from the publisher until we have one subscriber
   // to avoid discarding events before the subscriber had the chance to subscribe.
   override def subscribe(subscriber: Flow.Subscriber[_ >: Value]): Unit = {
-    connectionWatcherStart(this.connectionWatcher)
-
     if (this.subscriber == null) {
       this.subscriber = subscriber
       super.subscribe(subscriber)
@@ -89,24 +83,5 @@ private [faunadb] class BodyValueFlowProcessor(json: ObjectMapper, syncLastTxnTi
 
   private def requestOne(): Unit =
     subscription.request(1)
-
-  private def connectionWatcherStart(connectionWatcher:() => CompletableFuture[HttpResponse[Flow.Publisher[java.util.List[ByteBuffer]]]]): Unit = {
-    val infiniteLoop: Future[Unit] = Future {
-      while (!Thread.currentThread().isInterrupted()) {
-        connectionWatcher()
-          .toScala
-          .flatMap {
-            case successResponse if successResponse.statusCode() < 300 => Future { successResponse }
-            case errorResponse => Future {onError(new Throwable(s"Status code: $errorResponse.statusCode() Body: $errorResponse.body()"))}
-          }
-        Thread.sleep(10000)
-      }
-    }
-
-    infiniteLoop.onComplete {
-      case Success(value) => println("Succeed with: " + value)
-      case Failure(e) => onError(e)
-    }
-  }
 }
 

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -2263,9 +2263,9 @@ class ClientSpec
     )
 
     val counter = 100
-    def metricsQuery: Future[Value] = {
+    def metricsQuery: Future[MetricsResponse] = {
       val taskClient = clientPool(random.nextInt(9))
-      val result = taskClient.query(
+      val result = taskClient.queryWithMetrics(
         Map(
           Paginate(Documents(Collection(COLLECTION_NAME))),
           Lambda(nextRef => Select("data", Get(nextRef)))
@@ -2282,7 +2282,7 @@ class ClientSpec
 
     (Seq.fill(counter)(metricsQuery))
       .par
-      .foreach((result: Future[Value]) => noException should be thrownBy result.futureValue)
+      .foreach((result: Future[MetricsResponse]) => noException should be thrownBy result.futureValue)
 
     (Seq.fill(counter)(sumQuery))
       .par


### PR DESCRIPTION
This reverts commit e7d38cf84afa84b05b9593d7882d0e41f4c25b0c.

@erickpintor determined that this reverted code is causing the following issue: https://faunadb.atlassian.net/browse/FE-1880

Reverting the commit to unblock set streaming release for the JVM driver.