### PR TITLE
Add support for new traceparent and tags fields to outbound queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
         name: core
 
     environment:
-      SBT_VERSION: 1.4.7
+      SBT_VERSION: 1.7.2
       FAUNA_ROOT_KEY: secret
       FAUNA_DOMAIN: core
       FAUNA_SCHEME: http

--- a/faunadb-common/src/main/java/com/faunadb/common/models/request/RequestParameters.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/models/request/RequestParameters.java
@@ -1,0 +1,126 @@
+package com.faunadb.common.models.request;
+
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Defines parameters which be included with the outgoing request.
+ */
+public class RequestParameters {
+
+    private static final int MAX_TAGS_PER_REQUEST = 25;
+
+    private static final int KEY_CHAR_LIMIT = 40;
+    private static final int VALUE_CHAR_LIMIT = 80;
+
+    private static final Pattern ALLOWABLE_CHARACTER_REGEX = Pattern.compile("^\\w+$");
+
+    private final Optional<Duration> timeout;
+    private final Optional<String> traceId;
+    private final Map<String, String> tags;
+
+    /**
+     * Constructs a {@link RequestParameters} instance from a provided timeout
+     * @param timeout
+     * @return {@link RequestParameters}
+     */
+    public static RequestParameters fromOptionalTimeout(Optional<Duration> timeout) {
+        return new RequestParameters(timeout, Optional.empty(), new HashMap<>());
+    }
+
+    /**
+     * Constructs an empty {@link RequestParameters} instance
+     */
+    public RequestParameters() {
+        this.timeout = Optional.empty();
+        this.traceId = Optional.empty();
+        this.tags = new HashMap<>();
+    }
+
+    /**
+     * Constructs a {@link RequestParameters} instance, using the provided inputs.
+     * @param timeout Timeout for the request
+     * @param traceId A unique identifier for this query. Adheres to the
+     *                [W3C Trace Context](https://w3c.github.io/trace-context) spec.
+     * @param tags    Key-value pair metadata to associate with this query.
+     * @throws IllegalArgumentException If the number of tags provided exceeds the maximum.
+     */
+    public RequestParameters(Optional<Duration> timeout, Optional<String> traceId, Map<String, String> tags) {
+
+        if (tags == null) {
+            throw new IllegalArgumentException("Tags cannot be null. Consider passing an empty set instead");
+        } else if (tags.size() > MAX_TAGS_PER_REQUEST) {
+            throw new IllegalArgumentException(
+                    String.format("Maximum number of tags provided, current max is %s", MAX_TAGS_PER_REQUEST));
+        }
+
+        this.timeout = timeout;
+        this.traceId = traceId;
+        this.tags = new HashMap<>(getValidatedTags(tags));
+    }
+
+    /**
+     * Get the timeout associated with this request
+     * @return timeout
+     */
+    public Optional<Duration> getTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * Get the traceId associated with this request
+     * @return traceId
+     */
+    public Optional<String> getTraceId() {
+        return this.traceId;
+    }
+
+    /**
+     * Get the tags associated with this request
+     * @return tags
+     */
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+
+    private Map<String, String> getValidatedTags(Map<String, String> tags) {
+        tags.entrySet().stream().forEach(entry -> {
+            validateKey(entry.getKey());
+            validateValue(entry.getValue());
+        });
+        return tags;
+    }
+
+    private void validateKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Empty keys not allowed");
+        } else if (key.length() > KEY_CHAR_LIMIT) {
+            throw new IllegalArgumentException(
+                    String.format("Key, %s, is longer than the allowable limit of %d characters", key, KEY_CHAR_LIMIT));
+        }
+        Matcher m = ALLOWABLE_CHARACTER_REGEX.matcher(key);
+        if (!m.matches()) {
+            throw new IllegalArgumentException(String.format("Provided key, %s, contains invalid characters", key));
+        }
+    }
+
+    private void validateValue(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Empty values not allowed");
+        } else if (value.length() > VALUE_CHAR_LIMIT) {
+            throw new IllegalArgumentException(
+                    String.format("Value, %s, is longer than the allowable limit of %d characters", value,
+                                  VALUE_CHAR_LIMIT
+                    ));
+        }
+        Matcher m = ALLOWABLE_CHARACTER_REGEX.matcher(value);
+        if (!m.matches()) {
+            throw new IllegalArgumentException(String.format("Provided value, %s, contains invalid characters", value));
+        }
+    }
+}

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -114,31 +114,6 @@ public class ClientSpec {
     clientWithCustomHeaders = createFaunaClientWithCustomHeaders(serverKey.get(SECRET_FIELD));
   }
 
-  @AfterClass
-  public static void testDataCleanup() throws Exception {
-    rootClient.query(KeyFromSecret(ROOT_TOKEN))
-            .handle((v, ex) -> handleBadRequest(v, ex))
-            .thenApply((Value rootKey) ->
-                    rootClient.query(
-                            Let(
-                                    "rootKey", rootKey,
-                                    "keys", Map(Paginate(Keys()), Lambda(Value("ref"), Get(Var("ref")))),
-                                    "allKeysExceptRoot", getMap(rootKey),
-                                 "refsToRemove", Union(
-                                      Select(Arr(Value("data")), Paginate(Databases())),
-                                      Select(Arr(Value("data")), Paginate(Collections())),
-                                      Select(Arr(Value("data")), Paginate(Indexes())),
-                                      Select(Arr(Value("data")), Paginate(Functions())),
-                                      Select(Arr(Value("data")), Paginate(Keys())),
-                                      Select(Arr(Value("data")), Var("allKeysExceptRoot")))
-                ).in(
-                    Foreach(
-                            Var("refsToRemove"),
-                            Lambda(Value("ref"), If(Exists(Var("ref")), Delete(Var("ref")), NULL)))
-            )
-    ).handle(ClientSpec::handleBadRequest)).get();
-  }
-
   private static Expr getMap(Value rootKey) {
     return Map( checkNull(rootKey) ?
             Filter(Var("keys"),
@@ -3638,7 +3613,7 @@ public class ClientSpec {
     Value clazz = query(
       CreateCollection(
         Obj("name", Value(randomStartingWith("some_collection_"))))
-    ).get();
+                        ).get();
 
     return clazz.get(REF_FIELD);
   }

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -1,24 +1,23 @@
 package faunadb
 
 import com.codahale.metrics.MetricRegistry
-import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode, ObjectMapper}
 import com.fasterxml.jackson.databind.node.{ArrayNode, NullNode}
+import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.faunadb.common.Connection
 import com.faunadb.common.Connection.JvmDriver
+import com.faunadb.common.http.ResponseBodyStringProcessor
+import faunadb.FaunaClient.{EventField, json}
 import faunadb.errors._
 import faunadb.query.{Expr, Get}
-import faunadb.values.{ArrayV, Metrics, MetricsResponse, NullV, Value}
-import faunadb.FaunaClient.json
+import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
+import faunadb.types.RequestParameters
+import faunadb.values._
 
 import java.io.IOException
 import java.net.ConnectException
 import java.net.http.HttpResponse
 import java.util.concurrent.{CompletionException, Flow, TimeoutException}
-import com.faunadb.common.http.ResponseBodyStringProcessor
-import faunadb.FaunaClient.EventField
-import faunadb.streaming.{BodyValueFlowProcessor, SnapshotEventFlowProcessor}
-
 import scala.collection.JavaConverters._
 import scala.compat.java8.DurationConverters._
 import scala.compat.java8.FutureConverters._
@@ -153,7 +152,25 @@ class FaunaClient private (connection: Connection) {
     *         future is returned.
     */
   def query(expr: Expr, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] =
-    performRequest(json.valueToTree(expr), timeout)
+    query(expr, new RequestParameters(timeout))
+
+  /**
+   * Issues a query.
+   *
+   * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+   * @param ec the `ExecutionContext` used to run the query asynchronously.
+   * @param requestParameters Additional metadata to be passed along with the request.
+   * @return A [[scala.concurrent.Future]] containing the query result.
+   *         The result is an instance of [[faunadb.values.Result]],
+   *         which can be cast to a typed value using the
+   *         [[faunadb.values.Field]] API. If the query fails, failed
+   *         future is returned.
+   */
+  def query(
+             expr: Expr,
+             requestParameters: RequestParameters
+           )(implicit ec: ExecutionContext): Future[Value] =
+    performRequest(json.valueToTree(expr), requestParameters)
 
   /**
     * Issues a query.
@@ -170,7 +187,30 @@ class FaunaClient private (connection: Connection) {
     *         future is returned.
     */
   def queryWithMetrics(expr: Expr, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[MetricsResponse] =
-    performRequestWithMetrics(json.valueToTree(expr), timeout)
+    queryWithMetrics(expr, new RequestParameters(timeout))
+
+  /**
+   * Issues a query.
+   *
+   * @param expr the query to run, created using the query dsl helpers in [[faunadb.query]].
+   * @param ec the `ExecutionContext` used to run the query asynchronously.
+   * @param timeout the timeout for the current query. It replaces the timeout value set for this
+   *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+   *                milliseconds precision.
+   * @param traceId A unique identifier for this query. Adheres to the
+   *                [W3C Trace Context](https://w3c.github.io/trace-context) spec.
+   * @param tags    Key-value pair metadata to associate with this query.
+   * @return A [[scala.concurrent.Future]] containing the query result.
+   *         The result is an instance of [[faunadb.values.Result]],
+   *         which can be cast to a typed value using the
+   *         [[faunadb.values.Field]] API. If the query fails, failed
+   *         future is returned.
+   */
+  def queryWithMetrics(
+                        expr: Expr,
+                        requestParameters: RequestParameters
+                      )(implicit ec: ExecutionContext): Future[MetricsResponse] =
+    performRequestWithMetrics(json.valueToTree(expr), requestParameters)
 
   /**
     * Issues multiple queries as a single transaction.
@@ -218,13 +258,19 @@ class FaunaClient private (connection: Connection) {
     *         query fails, a failed future is returned.
     */
   def query(exprs: Iterable[Expr], timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[IndexedSeq[Value]] =
-    performRequest(json.valueToTree(exprs), timeout).map { result =>
+    performRequest(json.valueToTree(exprs), new RequestParameters(timeout)).map { result =>
       result.asInstanceOf[ArrayV].elems
     }
 
-  private def performRequestCommon[T](body: JsonNode, timeout: Option[FiniteDuration], handler: HttpResponse[String] => Future[T])(implicit ec: ExecutionContext): Future[T] = {
-    val javaTimeout = timeout.map(_.toJava).asJava
-    val response: Future[HttpResponse[String]] = connection.post("", body, javaTimeout).toScala
+  private def performRequestCommon[T](
+                                       body: JsonNode,
+                                       requestParameters: RequestParameters,
+                                       handler: HttpResponse[String] => Future[T]
+                                     )(implicit ec: ExecutionContext): Future[T] = {
+    val response: Future[HttpResponse[String]] = connection.post("",
+                                                                 body,
+                                                                 requestParameters.asJava)
+                                                           .toScala
 
     response
       .flatMap {
@@ -234,12 +280,20 @@ class FaunaClient private (connection: Connection) {
       .recoverWith(handleNetworkExceptions)
   }
 
-  private def performRequest(body: JsonNode, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[Value] = {
-    performRequestCommon(body, timeout, handleSuccessResponse)
+  private def performRequest(
+                              body: JsonNode,
+                              requestParameters: RequestParameters
+                            )(implicit ec: ExecutionContext): Future[Value] = {
+    performRequestCommon(body, requestParameters, handleSuccessResponse)
   }
 
-  private def performRequestWithMetrics(body: JsonNode, timeout: Option[FiniteDuration])(implicit ec: ExecutionContext): Future[MetricsResponse] = {
-    performRequestCommon(body, timeout, handleSuccessResponseWithMetrics)
+  private def performRequestWithMetrics(
+                                         body: JsonNode,
+                                         requestParameters: RequestParameters
+                                       )(implicit ec: ExecutionContext): Future[MetricsResponse] = {
+    performRequestCommon(body,
+                         requestParameters,
+                         handleSuccessResponseWithMetrics)
   }
 
   private def handleSuccessResponseWithMetrics(response: HttpResponse[String])(implicit ec: ExecutionContext): Future[MetricsResponse] = {

--- a/faunadb-scala/src/main/scala/faunadb/types/RequestParameters.scala
+++ b/faunadb-scala/src/main/scala/faunadb/types/RequestParameters.scala
@@ -1,0 +1,29 @@
+package faunadb.types
+
+import java.time.Duration
+import scala.collection.JavaConversions._
+import scala.compat.java8.DurationConverters.FiniteDurationops
+import scala.compat.java8.OptionConverters.RichOptionForJava8
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ *
+ * @param timeout the timeout for the current query. It replaces the timeout value set for this
+ *                [[faunadb.FaunaClient]] if any for the scope of this query. The timeout value has
+ *                milliseconds precision.
+ * @param traceId A unique identifier for this query. Adheres to the
+ *                [W3C Trace Context](https://w3c.github.io/trace-context) spec.
+ * @param tags    Key-value pair metadata to associate with this query.
+ */
+case class RequestParameters(timeout: Option[FiniteDuration] = None,
+                             traceId: Option[String] = None,
+                             tags: Map[String, String] = Map()) {
+  if (tags == null) {
+    throw new IllegalArgumentException("Tags cannot be null. Consider passing an empty set instead")
+  }
+  def timeoutAsJavaDuration: Option[Duration] = timeout.map(_.toJava)
+  def asJava: com.faunadb.common.models.request.RequestParameters =
+    new com.faunadb.common.models.request.RequestParameters(timeoutAsJavaDuration.asJava,
+                                                            traceId.asJava,
+                                                            mapAsJavaMap(tags))
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
     licenses := Seq("Mozilla Public License" -> url("https://www.mozilla.org/en-US/MPL/2.0/")),
     homepage := Some(url("https://github.com/fauna/faunadb-jvm")),
     publishMavenStyle := true,
-    publishArtifact in Test := false,
+    Test / publishArtifact := false,
     pomIncludeRepository := { _ => false },
     publishTo := {
       val nexus = "https://oss.sonatype.org"
@@ -93,7 +93,7 @@ object Settings {
 
     coverageEnabled := false,
 
-    javacOptions in (Compile, doc) := Seq(
+    Compile / doc / javacOptions := Seq(
       "-source", "11",
       "-link", javaDocUrl,
       "-link", metricsDocUrl
@@ -113,7 +113,7 @@ object Settings {
   lazy val faunadbJavaSettings = Seq(
     apiURL := Some(url(javaApiUrl)),
 
-    javacOptions in (Compile, doc) ++= Seq(
+    Compile / doc / javacOptions ++= Seq(
       "-linkoffline", commonApiUrl, "./faunadb-common/target/api"
     ),
 
@@ -131,7 +131,7 @@ object Settings {
     autoAPIMappings := true,
     apiURL := Some(url(scalaApiUrl)),
     apiMappings ++= {
-      val cp = (fullClasspath in Compile).value
+      val cp = (Compile / fullClasspath).value
       def findDep(org: String, name: String) = {
         for {
           entry <- cp

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -7,9 +7,9 @@ object Tasks {
   
   lazy val settings =
     Seq(
-      compileAll := (compile in Testing.LoadTest)
-        .dependsOn(compile in Test)
-        .dependsOn(compile in Compile)
+      compileAll := (Testing.LoadTest / compile)
+        .dependsOn(Test / compile)
+        .dependsOn(Compile / compile)
         .value)
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.7.2


### PR DESCRIPTION
### Background
This is a merge of https://github.com/fauna/faunadb-jvm/pull/358

### Commits
- Bump sbt version to 1.7.2
- Remove tear down method (#360) (#361)
- Add APIs for TraceId and Tags (#358)

### Description
Adding new implementation for traceparent and tags, see https://faunadb.atlassian.net/browse/FE-2383

### Testing
Added unit tests for Tag/RequestParameters validation.

### Out of scope
Code does not currently allow for injecting observer callbacks to inspect the response (namely, the response headers). Will discuss with team whether that is needed right now and tackle in a separate PR.