### PR TITLE
improve pipeline sbt output

### DIFF
--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "ls -la && sbt ++2.11.12 test"]
+    command: [sh, -c, "ls -la && sbt ++2.11.12 -Dsbt.supershell=false test"]
 
   tests-jdk-11-scala-2.12:
     environment:
@@ -38,7 +38,7 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "ls -la && sbt ++2.12.14 test"]
+    command: [sh, -c, "ls -la && sbt ++2.12.14 -Dsbt.supershell=false test"]
 
   tests-oracle-jdk-11-scala-2.11:
     environment:
@@ -56,7 +56,7 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "ls -la && sbt ++2.11.12 test"]
+    command: [sh, -c, "ls -la && sbt ++2.11.12 -Dsbt.supershell=false test"]
 
   tests-oracle-jdk-11-scala-2.12:
     environment:
@@ -74,4 +74,4 @@ services:
     volumes:
       - "../../:/tmp/app"
     working_dir: "/tmp/app"
-    command: [sh, -c, "ls -la && sbt ++2.12.14 test"]
+    command: [sh, -c, "ls -la && sbt ++2.12.14 -Dsbt.supershell=false test"]


### PR DESCRIPTION
Without this set the shell shows progress in a way that doesn't work well in a pipeline.  Output from the test commands will be a lot more clear with this set.