### PR TITLE
Bump patch version to add deprecation warnings

### DIFF
--- a/faunadb-common/src/main/java/com/faunadb/common/Connection.java
+++ b/faunadb-common/src/main/java/com/faunadb/common/Connection.java
@@ -33,7 +33,13 @@ import static java.lang.String.format;
  *
  * <p>Relies on {@link java.net.http.HttpClient}
  * for the underlying implementation.</p>
+ *
+ * @deprecated
+ * Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
+ * Fauna accounts created after August 21, 2024 must use FQL v10.
+ * Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.
  */
+@Deprecated(since = "4.5.1")
 public class Connection {
 
   private static final String API_VERSION = "4";

--- a/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/FaunaClient.java
@@ -65,7 +65,13 @@ import static com.faunadb.client.types.Codec.VALUE;
  * </pre>
  *
  * @see com.faunadb.client.query.Language
+ *
+ * @deprecated
+ * Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
+ * Fauna accounts created after August 21, 2024 must use FQL v10.
+ * Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.
  */
+@Deprecated(since = "4.5.1")
 public class FaunaClient {
 
   /**

--- a/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
+++ b/faunadb-java/src/main/java/com/faunadb/client/types/MetricsResponse.java
@@ -51,12 +51,10 @@ public class MetricsResponse {
         QUERY_BYTES_IN("x-query-bytes-in"),
         QUERY_BYTES_OUT("x-query-bytes-out"),
         QUERY_TIME("x-query-time"),
-        READ_OPS("x-read-ops"),
         STORAGE_BYTES_READ("x-storage-bytes-read"),
         STORAGE_BYTES_WRITE("x-storage-bytes-write"),
         TXN_RETRIES("x-txn-retries"),
-        TXN_TIME("x-txn-time"),
-        WRITE_OPS("x-write-ops");
+        TXN_TIME("x-txn-time");
 
         private final String metric;
 

--- a/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
+++ b/faunadb-java/src/test/java/com/faunadb/client/ClientSpec.java
@@ -325,12 +325,10 @@ public class ClientSpec {
     Optional<String> queryBytesIn = metricsResponse.getMetric(MetricsResponse.Metrics.QUERY_BYTES_IN);
     Optional<String> queryBytesOut = metricsResponse.getMetric(MetricsResponse.Metrics.QUERY_BYTES_OUT);
     Optional<String> queryTime = metricsResponse.getMetric(MetricsResponse.Metrics.QUERY_TIME);
-    Optional<String> readOps = metricsResponse.getMetric(MetricsResponse.Metrics.READ_OPS);
     Optional<String> storageBytesRead = metricsResponse.getMetric(MetricsResponse.Metrics.STORAGE_BYTES_READ);
     Optional<String> storageBytesWrite = metricsResponse.getMetric(MetricsResponse.Metrics.STORAGE_BYTES_WRITE);
     Optional<String> txnRetries = metricsResponse.getMetric(MetricsResponse.Metrics.TXN_RETRIES);
     Optional<String> txnTime = metricsResponse.getMetric(MetricsResponse.Metrics.TXN_TIME);
-    Optional<String> writeOps = metricsResponse.getMetric(MetricsResponse.Metrics.WRITE_OPS);
 
     assertThat(byteReadOps.isPresent(), is(true));
     assertThat(byteWriteOps.isPresent(), is(true));
@@ -339,12 +337,10 @@ public class ClientSpec {
     assertThat(queryBytesIn.isPresent(), is(true));
     assertThat(queryBytesOut.isPresent(), is(true));
     assertThat(queryTime.isPresent(), is(true));
-    assertThat(readOps.isPresent(), is(true));
     assertThat(storageBytesRead.isPresent(), is(true));
     assertThat(storageBytesWrite.isPresent(), is(true));
     assertThat(txnRetries.isPresent(), is(true));
     assertThat(txnTime.isPresent(), is(true));
-    assertThat(writeOps.isPresent(), is(true));
   }
 
   @Test
@@ -3171,7 +3167,7 @@ public class ClientSpec {
   @Test
   public void streamFailsIfQueryIsNotReadOnly() throws Exception {
     thrown.expectCause(isA(BadRequestException.class));
-    thrown.expectMessage(containsString("invalid expression: Write effect in read-only query expression."));
+    thrown.expectMessage(containsString("invalid expression: Call performs a write, which is not allowed in stream requests."));
 
     adminClient.stream(CreateCollection(Collection("spells"))).get();
   }

--- a/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
+++ b/faunadb-scala/src/main/scala/faunadb/FaunaClient.scala
@@ -25,7 +25,19 @@ import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
-/** Companion object to the FaunaClient class. */
+/**
+  * Companion object to the FaunaClient class.
+  *
+  * @deprecated
+  * Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
+  * Fauna accounts created after August 21, 2024 must use FQL v10.
+  * Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.
+  */
+@deprecated("Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10. " +
+  "Fauna accounts created after August 21, 2024 must use FQL v10. " +
+  "Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.",
+  "4.5.1"
+)
 object FaunaClient {
 
   // singleton ObjectMapper for all clients
@@ -43,7 +55,17 @@ object FaunaClient {
     *                     milliseconds precision. If not provided, a default timeout value is set on the server side.
     * @param userAgent A value used for the User-Agent HTTP header.
     * @return A configured FaunaClient instance.
+    *
+    * @deprecated
+    * Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
+    * Fauna accounts created after August 21, 2024 must use FQL v10.
+    * Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.
     */
+  @deprecated("Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10. " +
+    "Fauna accounts created after August 21, 2024 must use FQL v10. " +
+    "Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.",
+    "4.5.1"
+  )
   def apply(
     secret: String = null,
     endpoint: String = null,
@@ -105,7 +127,17 @@ object FaunaClient {
   * }}}
   *
   * @constructor create a new client with a configured [[com.faunadb.common.Connection]].
+  *
+  * @deprecated
+  * Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
+  * Fauna accounts created after August 21, 2024 must use FQL v10.
+  * Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.
   */
+@deprecated("Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10. " +
+  "Fauna accounts created after August 21, 2024 must use FQL v10. " +
+  "Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.",
+  "4.5.1"
+)
 class FaunaClient private (connection: Connection) {
 
   /**

--- a/faunadb-scala/src/main/scala/faunadb/values/Metrics.scala
+++ b/faunadb-scala/src/main/scala/faunadb/values/Metrics.scala
@@ -10,12 +10,10 @@ object Metrics extends Enumeration {
   val QueryBytesIn = Value("x-query-bytes-in")
   val QueryBytesOut = Value("x-query-bytes-out")
   val QueryTime = Value("x-query-time")
-  val ReadOps = Value("x-read-ops")
   val StorageBytesRead = Value("x-storage-bytes-read")
   val StorageBytesWrite = Value("x-storage-bytes-write")
   val TxnRetries = Value("x-txn-retries")
   val TxnTime = Value("x-txn-time")
-  val WriteOps = Value("x-write-ops")
 
   val All = values.toList
 }

--- a/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
+++ b/faunadb-scala/src/test/scala/faunadb/ClientSpec.scala
@@ -524,12 +524,10 @@ class ClientSpec
     val queryBytesIn = metricsResponse.getMetric(Metrics.QueryBytesIn)
     val queryBytesOut = metricsResponse.getMetric(Metrics.QueryBytesOut)
     val queryTime = metricsResponse.getMetric(Metrics.QueryTime)
-    val readOps = metricsResponse.getMetric(Metrics.ReadOps)
     val storageBytesRead = metricsResponse.getMetric(Metrics.StorageBytesRead)
     val storageBytesWrite = metricsResponse.getMetric(Metrics.StorageBytesWrite)
     val txnRetries = metricsResponse.getMetric(Metrics.TxnRetries)
     val txnTime = metricsResponse.getMetric(Metrics.TxnTime)
-    val writeOps = metricsResponse.getMetric(Metrics.WriteOps)
 
     byteReadOps.isDefined should equal (true)
     byteWriteOps.isDefined should equal (true)
@@ -538,12 +536,10 @@ class ClientSpec
     queryBytesIn.isDefined should equal (true)
     queryBytesOut.isDefined should equal (true)
     queryTime.isDefined should equal (true)
-    readOps.isDefined should equal (true)
     storageBytesRead.isDefined should equal (true)
     storageBytesWrite.isDefined should equal (true)
     txnRetries.isDefined should equal (true)
     txnTime.isDefined should equal (true)
-    writeOps.isDefined should equal (true)
   }
 
   it should "paginate with cursor object" in {
@@ -2163,7 +2159,7 @@ class ClientSpec
   it should "stream return error if the query is not readonly" in {
     val err = client.stream(Create(Collection("spells"), Obj("data" -> Obj("testField" -> "testValue0")))).failed.futureValue
     err shouldBe a[BadRequestException]
-    err.getMessage should include("Write effect in read-only query expression.")
+    err.getMessage should include("Call performs a write, which is not allowed in stream requests.")
   }
 
   it should "stream on document reference contains `document` field by default" in {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ import scoverage.ScoverageSbtPlugin.autoImport._
 
 object Settings {
 
-  lazy val driverVersion = "4.5.0"
+  lazy val driverVersion = "4.5.1"
 
   lazy val scala211 = "2.11.12"
   lazy val scala212 = "2.12.14"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,6 +61,11 @@ object Settings {
           <organizationUrl>https://fauna.com</organizationUrl>
         </developer>
       </developers>
+      <deprecated>true</deprecated>
+      <deprecation>
+        <message>v4 EOL notice</message>
+        <since>4.5.1</since>
+      </deprecation>
     ),
     usePgpKeyHex(sys.env.getOrElse("GPG_SIGNING_KEY", "0")),
     pgpPassphrase := sys.env.get("GPG_PASSPHRASE") map (_.toArray),


### PR DESCRIPTION
[FE-5838](https://faunadb.atlassian.net/browse/FE-5838)

Note the following with deprecation warnings:

Fauna is decommissioning FQL v4 on June 30, 2025. This driver is not compatible with FQL v10.
Fauna accounts created after August 21, 2024 must use FQL v10.
Ensure you migrate existing projects to the official v10 driver by the v4 EOL date: https://github.com/fauna/fauna-jvm.

[FE-5838]: https://faunadb.atlassian.net/browse/FE-5838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ